### PR TITLE
support instance user_data_raw

### DIFF
--- a/tencentcloud/resource_tc_instance.go
+++ b/tencentcloud/resource_tc_instance.go
@@ -1,6 +1,7 @@
 package tencentcloud
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -223,8 +224,16 @@ func resourceTencentCloudInstance() *schema.Resource {
 				Sensitive: true,
 			},
 			"user_data": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"user_data_raw"},
+			},
+			"user_data_raw": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"user_data"},
 			},
 
 			// Computed values.
@@ -367,6 +376,12 @@ func resourceTencentCloudInstanceCreate(d *schema.ResourceData, m interface{}) e
 		data := v.(string)
 		if len(data) > 0 {
 			params["UserData"] = data
+		}
+	}
+	if v, ok := d.GetOk("user_data_raw"); ok {
+		data := v.(string)
+		if len(data) > 0 {
+			params["UserData"] = base64.StdEncoding.EncodeToString([]byte(data))
 		}
 	}
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -140,6 +140,8 @@ The following arguments are supported:
 
 * `user_data` - (Optional) The user data to be specified into this instance. Must be encrypted in base64 format and limited in 16 KB.
 
+* `user_data_raw` - (Optional) The user data to be specified into this instance, plain text. Conflicts with `user_data`. Limited in 16 KB after encrypted in base64 format.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
even though we can use terraform builtin function base64encode() to
generate base64 encoded string from raw text, we still provide this
option for users.

fix #4