### PR TITLE
bug fix project_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## 1.9.0 (Unreleased)
-## 1.8.0 (Unreleased)
+
+ENHANCEMENTS:
+
+* update to `v0.12.1` Terraform SDK version
+
+BUG FIXIES:
+
+* data/tencentcloud_security_group: `project_id` remote API return sometime is string type.
+* resource/tencentcloud_security_group: just like `data/tencentcloud_security_group`
+
+## 1.8.0 (June 11, 2019)
 
 FEATURES:
 * **New Data Source**: `tencentcloud_as_scaling_configs`

--- a/tencentcloud/data_source_tc_security_group.go
+++ b/tencentcloud/data_source_tc_security_group.go
@@ -3,7 +3,10 @@ package tencentcloud
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
+	"reflect"
+	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -65,12 +68,12 @@ func dataSourceTencentCloudSecurityGroupRead(d *schema.ResourceData, m interface
 		Data    struct {
 			TotalNum int `json:"totalNum"`
 			Detail   []struct {
-				SgId             string `json:"sgId"`
-				SgName           string `json:"sgName"`
-				SgRemark         string `json:"sgRemark"`
-				BeAssociateCount int    `json:"beAssociateCount"`
-				CreateTime       string `json:"createTime"`
-				ProjectId        int    `json:"projectId"`
+				SgId             string      `json:"sgId"`
+				SgName           string      `json:"sgName"`
+				SgRemark         string      `json:"sgRemark"`
+				BeAssociateCount int         `json:"beAssociateCount"`
+				CreateTime       string      `json:"createTime"`
+				ProjectId        interface{} `json:"projectId"`
 			}
 		}
 	}
@@ -94,7 +97,16 @@ func dataSourceTencentCloudSecurityGroupRead(d *schema.ResourceData, m interface
 	d.Set("description", sg.SgRemark)
 	d.Set("create_time", sg.CreateTime)
 	d.Set("be_associate_count", sg.BeAssociateCount)
-	d.Set("project_id", sg.ProjectId)
 
+	if "string" == reflect.TypeOf(sg.ProjectId).String() {
+		if intVal, err := strconv.ParseInt(sg.ProjectId.(string), 10, 64); err != nil {
+			return fmt.Errorf("create security_group project ParseInt  error ,%s", err.Error())
+		} else {
+			d.Set("project_id", int(intVal))
+		}
+
+	} else {
+		d.Set("project_id", sg.ProjectId.(int))
+	}
 	return nil
 }

--- a/tencentcloud/resource_tc_security_group.go
+++ b/tencentcloud/resource_tc_security_group.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"reflect"
 	"strconv"
 	"time"
 
@@ -106,9 +107,9 @@ func resourceTencentCloudSecurityGroupRead(d *schema.ResourceData, m interface{}
 		Data    struct {
 			TotalNum int `json:"totalNum"`
 			Detail   []struct {
-				SgName    string `json:"sgName"`
-				SgRemark  string `json:"sgRemark"`
-				ProjectId int    `json:"projectId"`
+				SgName    string      `json:"sgName"`
+				SgRemark  string      `json:"sgRemark"`
+				ProjectId interface{} `json:"projectId"`
 			}
 		}
 	}
@@ -127,7 +128,17 @@ func resourceTencentCloudSecurityGroupRead(d *schema.ResourceData, m interface{}
 	sg := jsonresp.Data.Detail[0]
 	d.Set("name", sg.SgName)
 	d.Set("description", sg.SgRemark)
-	d.Set("project_id", sg.ProjectId)
+
+	if "string" == reflect.TypeOf(sg.ProjectId).String() {
+		if intVal, err := strconv.ParseInt(sg.ProjectId.(string), 10, 64); err != nil {
+			return fmt.Errorf("create security_group project ParseInt  error ,%s", err.Error())
+		} else {
+			d.Set("project_id", int(intVal))
+		}
+	} else {
+		d.Set("project_id", sg.ProjectId.(int))
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
data/tencentcloud_security_group: `project_id` remote API return sometime is string type.
resource/tencentcloud_security_group: just like `data/tencentcloud_security_group`