### PR TITLE
bugfixed on tencentcloud_instance and tencentcloud_eip_association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
-## 1.10.0 (Unreleased)
+## 1.12.0 (Unreleased)
+
+BUG FIXIES:
+
+* resource/tencentcloud_instance: fixed issue when data disks set as delete_with_instance not works.
+* resource/tencentcloud_instance: if managed public_ip manually, please don't define `allocate_public_ip` ([#62](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/62)).
+* resource/tencentcloud_eip_association: fixed issue when instances were manually deleted ([#60](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/60)).
+
+## 1.11.0 (July 02, 2019)
+
+FEATURES:
+* **New Data Source**: `tencentcloud_ccn_instances`
+* **New Data Source**: `tencentcloud_ccn_bandwidth_limits`
+* **New Resource**: `tencentcloud_ccn`
+* **New Resource**: `tencentcloud_ccn_attachment`
+* **New Resource**: `tencentcloud_ccn_bandwidth_limit`
+
+## 1.10.0 (June 27, 2019)
 
 ENHANCEMENTS:
 

--- a/tencentcloud/resource_tc_eip_association.go
+++ b/tencentcloud/resource_tc_eip_association.go
@@ -158,7 +158,9 @@ func resourceTencentCloudEipAssociationDelete(d *schema.ResourceData, meta inter
 		}
 
 		status := *eip.AddressStatus
-		if goset.IsIncluded([]string{
+		if status == tencentCloudApiEipStatusUnbind {
+			return nil
+		} else if goset.IsIncluded([]string{
 			tencentCloudApiEipStatusBind,
 			tencentCloudApiEipStatusBindEni,
 		}, status) {

--- a/tencentcloud/resource_tc_instance.go
+++ b/tencentcloud/resource_tc_instance.go
@@ -152,6 +152,7 @@ func resourceTencentCloudInstance() *schema.Resource {
 			"allocate_public_ip": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 			// vpc
 			"vpc_id": {

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an eip resource associated with other resource like CVM or ENI.
 
+~> **NOTE:** Please DO NOT define `allocate_public_ip` in `tencentcloud_instance` resource.
+
 ## Example Usage
 
 Basic Usage

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides an eip resource associated with other resource like CVM or ENI.
 
-~> **NOTE:** Please DO NOT define `allocate_public_ip` in `tencentcloud_instance` resource.
+~> **NOTE:** Please DO NOT define `allocate_public_ip` in `tencentcloud_instance` resource when using `tencentcloud_eip_association`.
 
 ## Example Usage
 


### PR DESCRIPTION
BUG FIXIES:

* resource/tencentcloud_instance: fixed issue when data disks set as delete_with_instance not works.
* resource/tencentcloud_instance: if managed public_ip manually, please don't define `allocate_public_ip` ([#62](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/62)).
* resource/tencentcloud_eip_association: fixed issue when instances were manually deleted ([#60](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/60)).