### PR TITLE
docs: Formalize inline HCL codes in docs

### DIFF
--- a/website/docs/d/as_scaling_configs.html.markdown
+++ b/website/docs/d/as_scaling_configs.html.markdown
@@ -14,8 +14,8 @@ Use this data source to query scaling configuration information.
 
 ```hcl
 data "tencentcloud_as_scaling_configs" "as_configs" {
-    configuration_id   = "asc-oqio4yyj"
-    result_output_file = "my_test_path"
+  configuration_id   = "asc-oqio4yyj"
+  result_output_file = "my_test_path"
 }
 ```
 

--- a/website/docs/d/as_scaling_groups.html.markdown
+++ b/website/docs/d/as_scaling_groups.html.markdown
@@ -14,9 +14,9 @@ Use this data source to query the detail information of an existing autoscaling 
 
 ```hcl
 data "tencentcloud_as_scaling_groups" "as_scaling_groups" {
-    scaling_group_name  = "myasgroup"
-    configureation_id   = "asc-oqio4yyj"
-    result_output_file  = "my_test_path"
+  scaling_group_name = "myasgroup"
+  configureation_id  = "asc-oqio4yyj"
+  result_output_file = "my_test_path"
 }
 ```
 

--- a/website/docs/d/as_scaling_policies.html.markdown
+++ b/website/docs/d/as_scaling_policies.html.markdown
@@ -14,8 +14,8 @@ Use this data source to query detailed information of scaling policy.
 
 ```hcl
 data "tencentcloud_as_scaling_policies" "as_scaling_policies" {
-    scaling_policy_id      = "asg-mvyghxu7"
-    result_output_file    = "mytestpath"
+  scaling_policy_id  = "asg-mvyghxu7"
+  result_output_file = "mytestpath"
 }
 ```
 

--- a/website/docs/d/cbs_snapshots.html.markdown
+++ b/website/docs/d/cbs_snapshots.html.markdown
@@ -14,8 +14,8 @@ Use this data source to query detailed information of CBS snapshots.
 
 ```hcl
 data "tencentcloud_cbs_snapshots" "snapshots" {
-    snapshot_id        = "snap-f3io7adt"
-    result_output_file = "mytestpath"
+  snapshot_id        = "snap-f3io7adt"
+  result_output_file = "mytestpath"
 }
 ```
 

--- a/website/docs/d/cbs_storages.html.markdown
+++ b/website/docs/d/cbs_storages.html.markdown
@@ -14,8 +14,8 @@ Use this data source to query detailed information of CBS storages.
 
 ```hcl
 data "tencentcloud_cbs_storages" "storages" {
-    storage_id         = "disk-kdt0sq6m"
-    result_output_file = "mytestpath"
+  storage_id         = "disk-kdt0sq6m"
+  result_output_file = "mytestpath"
 }
 ```
 

--- a/website/docs/d/ccn_bandwidth_limits.html.markdown
+++ b/website/docs/d/ccn_bandwidth_limits.html.markdown
@@ -14,22 +14,22 @@ Use this data source to query detailed information of CCN bandwidth limits.
 
 ```hcl
 variable "other_region1" {
-    default = "ap-shanghai"
+  default = "ap-shanghai"
 }
-resource "tencentcloud_ccn" "main"{
-	name ="ci-temp-test-ccn"
-	description="ci-temp-test-ccn-des"
-	qos ="AG"
+resource "tencentcloud_ccn" "main" {
+  name        = "ci-temp-test-ccn"
+  description = "ci-temp-test-ccn-des"
+  qos         = "AG"
 }
 
 data "tencentcloud_ccn_bandwidth_limits" "limit" {
-	ccn_id ="${tencentcloud_ccn.main.id}"
+  ccn_id = "${tencentcloud_ccn.main.id}"
 }
 
 resource "tencentcloud_ccn_bandwidth_limit" "limit1" {
-	ccn_id ="${tencentcloud_ccn.main.id}"
-	region ="${var.other_region1}"
-	bandwidth_limit = 500
+  ccn_id          = "${tencentcloud_ccn.main.id}"
+  region          = "${var.other_region1}"
+  bandwidth_limit = 500
 }
 ```
 

--- a/website/docs/d/ccn_instances.html.markdown
+++ b/website/docs/d/ccn_instances.html.markdown
@@ -13,18 +13,18 @@ Use this data source to query detailed information of CCN instances.
 ## Example Usage
 
 ```hcl
-resource "tencentcloud_ccn" "main"{
-	name ="ci-temp-test-ccn"
-	description="ci-temp-test-ccn-des"
-	qos ="AG"
+resource "tencentcloud_ccn" "main" {
+  name        = "ci-temp-test-ccn"
+  description = "ci-temp-test-ccn-des"
+  qos         = "AG"
 }
 
-data "tencentcloud_ccn_instances" "id_instances"{
-	ccn_id = "${tencentcloud_ccn.main.id}"
+data "tencentcloud_ccn_instances" "id_instances" {
+  ccn_id = "${tencentcloud_ccn.main.id}"
 }
 
-data "tencentcloud_ccn_instances" "name_instances"{
-	name = "${tencentcloud_ccn.main.name}"
+data "tencentcloud_ccn_instances" "name_instances" {
+  name = "${tencentcloud_ccn.main.name}"
 }
 ```
 

--- a/website/docs/d/container_cluster_instances.html.markdown
+++ b/website/docs/d/container_cluster_instances.html.markdown
@@ -14,7 +14,7 @@ Use this data source to get all instances in a specific cluster.
 
 ```hcl
 data "tencentcloud_container_cluster_instances" "foo_instance" {
-    cluster_id = "cls-abcdefg"
+  cluster_id = "cls-abcdefg"
 }
 ```
 

--- a/website/docs/d/cos_bucket_object.html.markdown
+++ b/website/docs/d/cos_bucket_object.html.markdown
@@ -14,9 +14,9 @@ Use this data source to query the metadata of an object stored inside a bucket.
 
 ```hcl
 data "tencentcloud_cos_bucket_object" "mycos" {
-    bucket = "mycos-test-1258798060"
-    key    = "hello-world.py"
-    result_output_file  = "TFresults"
+  bucket             = "mycos-test-1258798060"
+  key                = "hello-world.py"
+  result_output_file = "TFresults"
 }
 ```
 

--- a/website/docs/d/cos_buckets.html.markdown
+++ b/website/docs/d/cos_buckets.html.markdown
@@ -14,8 +14,8 @@ Use this data source to query the COS buckets of the current Tencent Cloud user.
 
 ```hcl
 data "tencentcloud_cos_buckets" "cos_buckets" {
-	bucket_prefix = "tf-bucket-"
-    result_output_file = "mytestpath"
+  bucket_prefix      = "tf-bucket-"
+  result_output_file = "mytestpath"
 }
 ```
 

--- a/website/docs/d/dc_instances.html.markdown
+++ b/website/docs/d/dc_instances.html.markdown
@@ -13,12 +13,12 @@ Use this data source to query detailed information of DC instances.
 ## Example Usage
 
 ```hcl
-data "tencentcloud_dc_instances" "name_select"{
-    name = "t"
+data "tencentcloud_dc_instances" "name_select" {
+  name = "t"
 }
 
-data "tencentcloud_dc_instances"  "id" {
-    dcx_id = "dc-kax48sg7"
+data "tencentcloud_dc_instances" "id" {
+  dcx_id = "dc-kax48sg7"
 }
 
 ```

--- a/website/docs/d/dcx_instances.html.markdown
+++ b/website/docs/d/dcx_instances.html.markdown
@@ -13,12 +13,12 @@ Use this data source to query detailed information of dedicated tunnels instance
 ## Example Usage
 
 ```hcl
-data "tencentcloud_dcx_instances" "name_select"{
-    name = "main"
+data "tencentcloud_dcx_instances" "name_select" {
+  name = "main"
 }
 
-data "tencentcloud_dcx_instances"  "id" {
-    dcx_id = "dcx-3ikuw30k"
+data "tencentcloud_dcx_instances" "id" {
+  dcx_id = "dcx-3ikuw30k"
 }
 
 ```

--- a/website/docs/d/mysql_backup_list.html.markdown
+++ b/website/docs/d/mysql_backup_list.html.markdown
@@ -14,8 +14,8 @@ Use this data source to query the list of backup databases.
 
 ```hcl
 data "tencentcloud_mysql_backup_list" "default" {
-  mysql_id = "my-test-database"
-  max_number = 10
+  mysql_id           = "my-test-database"
+  max_number         = 10
   result_output_file = "mytestpath"
 }
 ```

--- a/website/docs/d/mysql_instance.html.markdown
+++ b/website/docs/d/mysql_instance.html.markdown
@@ -13,8 +13,8 @@ Use this data source to get information about a MySQL instance.
 ## Example Usage
 
 ```hcl
-data "tencentcloud_mysql_instance" "database"{
-  mysql_id = "my-test-database"
+data "tencentcloud_mysql_instance" "database" {
+  mysql_id           = "my-test-database"
   result_output_file = "mytestpath"
 }
 ```

--- a/website/docs/d/mysql_parameter_list.html.markdown
+++ b/website/docs/d/mysql_parameter_list.html.markdown
@@ -14,8 +14,8 @@ Use this data source to get information about a parameter group of a database in
 
 ```hcl
 data "tencentcloud_mysql_parameter_list" "mysql" {
-  mysql_id = "my-test-database"
-  engine_version = "5.5"
+  mysql_id           = "my-test-database"
+  engine_version     = "5.5"
   result_output_file = "mytestpath"
 }
 ```

--- a/website/docs/d/mysql_zone_config.html.markdown
+++ b/website/docs/d/mysql_zone_config.html.markdown
@@ -14,7 +14,7 @@ Use this data source to query the available database specifications for differen
 
 ```hcl
 data "tencentcloud_mysql_zone_config" "mysql" {
-  region = "ap-guangzhou"
+  region             = "ap-guangzhou"
   result_output_file = "mytestpath"
 }
 ```

--- a/website/docs/d/nats.html.markdown
+++ b/website/docs/d/nats.html.markdown
@@ -30,7 +30,7 @@ data "tencentcloud_nats" "multi_nat" {
   name           = "terraform test"
   vpc_id         = "vpc-ezij4ltv"
   max_concurrent = 3000000
-  bandwidth      = 500 
+  bandwidth      = 500
 }
 ```
 

--- a/website/docs/d/redis_instances.html.markdown
+++ b/website/docs/d/redis_instances.html.markdown
@@ -14,11 +14,11 @@ Use this data source to query the detail information of redis instance.
 
 ```hcl
 data "tencentcloud_redis_instances" "redislab" {
-    zone                = "ap-hongkong-1"
-    search_key          = "myredis"
-    project_id          = 0
-    limit               = 20
-    result_output_file  = "/tmp/redis_instances"
+  zone               = "ap-hongkong-1"
+  search_key         = "myredis"
+  project_id         = 0
+  limit              = 20
+  result_output_file = "/tmp/redis_instances"
 }
 ```
 

--- a/website/docs/d/redis_zone_config.html.markdown
+++ b/website/docs/d/redis_zone_config.html.markdown
@@ -14,8 +14,8 @@ Use this data source to query which instance types of Redis are available in a s
 
 ```hcl
 data "tencentcloud_redis_zone_config" "redislab" {
-    region             = "ap-hongkong"
-    result_output_file = "/temp/mytestpath"
+  region             = "ap-hongkong"
+  result_output_file = "/temp/mytestpath"
 }
 ```
 

--- a/website/docs/d/vpc_instances.html.markdown
+++ b/website/docs/d/vpc_instances.html.markdown
@@ -14,16 +14,16 @@ Use this data source to query vpc instances' information.
 
 ```hcl
 resource "tencentcloud_vpc" "foo" {
-    name="guagua_vpc_instance_test"
-    cidr_block="10.0.0.0/16"
+  name       = "guagua_vpc_instance_test"
+  cidr_block = "10.0.0.0/16"
 }
 
 data "tencentcloud_vpc_instances" "id_instances" {
-	vpc_id="${tencentcloud_vpc.foo.id}"
+  vpc_id = "${tencentcloud_vpc.foo.id}"
 }
 
 data "tencentcloud_vpc_instances" "name_instances" {
-	name="${tencentcloud_vpc.foo.name}"
+  name = "${tencentcloud_vpc.foo.name}"
 }
 ```
 

--- a/website/docs/d/vpc_route_tables.html.markdown
+++ b/website/docs/d/vpc_route_tables.html.markdown
@@ -14,24 +14,24 @@ Use this data source to query vpc route tables information.
 
 ```hcl
 variable "availability_zone" {
-	default = "ap-guangzhou-3"
+  default = "ap-guangzhou-3"
 }
 
 resource "tencentcloud_vpc" "foo" {
-    name="guagua-ci-temp-test"
-    cidr_block="10.0.0.0/16"
+  name       = "guagua-ci-temp-test"
+  cidr_block = "10.0.0.0/16"
 }
 
 resource "tencentcloud_route_table" "route_table" {
-   vpc_id = "${tencentcloud_vpc.foo.id}"
-   name = "ci-temp-test-rt"
+  vpc_id = "${tencentcloud_vpc.foo.id}"
+  name   = "ci-temp-test-rt"
 }
 
 data "tencentcloud_vpc_route_tables" "id_instances" {
-	route_table_id="${tencentcloud_route_table.route_table.id}"
+  route_table_id = "${tencentcloud_route_table.route_table.id}"
 }
 data "tencentcloud_vpc_route_tables" "name_instances" {
-	name="${tencentcloud_route_table.route_table.name}"
+  name = "${tencentcloud_route_table.route_table.name}"
 }
 ```
 

--- a/website/docs/d/vpc_subnets.html.markdown
+++ b/website/docs/d/vpc_subnets.html.markdown
@@ -14,25 +14,25 @@ Use this data source to query vpc subnets information.
 
 ```hcl
 variable "availability_zone" {
-	default = "ap-guangzhou-3"
+  default = "ap-guangzhou-3"
 }
 
 resource "tencentcloud_vpc" "foo" {
-    name="guagua_vpc_instance_test"
-    cidr_block="10.0.0.0/16"
+  name       = "guagua_vpc_instance_test"
+  cidr_block = "10.0.0.0/16"
 }
 resource "tencentcloud_subnet" "subnet" {
-	availability_zone="${var.availability_zone}"
-	name="guagua_vpc_subnet_test"
-	vpc_id="${tencentcloud_vpc.foo.id}"
-	cidr_block="10.0.20.0/28"
-	is_multicast=false
+  availability_zone = "${var.availability_zone}"
+  name              = "guagua_vpc_subnet_test"
+  vpc_id            = "${tencentcloud_vpc.foo.id}"
+  cidr_block        = "10.0.20.0/28"
+  is_multicast      = false
 }
 data "tencentcloud_vpc_subnets" "id_instances" {
-	subnet_id="${tencentcloud_subnet.subnet.id}"
+  subnet_id = "${tencentcloud_subnet.subnet.id}"
 }
 data "tencentcloud_vpc_subnets" "name_instances" {
-	name="${tencentcloud_subnet.subnet.name}"
+  name = "${tencentcloud_subnet.subnet.name}"
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -38,7 +38,7 @@ resource "tencentcloud_instance" "web" {
 
 # Create key pair with your public key
 resource "tencentcloud_key_pair" "my_ssh_key" {
-  key_name = "from_terraform_public_key"
+  key_name   = "from_terraform_public_key"
   public_key = "ssh-rsa AAAAB3NzaSuperLongString foo@bar"
 }
 
@@ -83,7 +83,7 @@ Usage:
 
 ```hcl
 provider "tencentcloud" {
-  secret_id = "${var.secret_id}"
+  secret_id  = "${var.secret_id}"
   secret_key = "${var.secret_key}"
   region     = "${var.region}"
 }

--- a/website/docs/r/alb_server_attachment.html.markdown
+++ b/website/docs/r/alb_server_attachment.html.markdown
@@ -17,18 +17,18 @@ Provides Load Balancer server attachment resource.
 ```hcl
 resource "tencentcloud_alb_server_attachment" "service1" {
   loadbalancer_id = "lb-qk1dqox5"
-  listener_id = "lbl-ghoke4tl"
-  location_id = "loc-i858qv1l"
+  listener_id     = "lbl-ghoke4tl"
+  location_id     = "loc-i858qv1l"
   backends = [
     {
       instance_id = "ins-4j30i5pe"
-      port = 80
-      weight = 50
+      port        = 80
+      weight      = 50
     },
     {
       instance_id = "ins-4j30i5pe"
-      port = 8080
-      weight = 50
+      port        = 8080
+      weight      = 50
     }
   ]
 }

--- a/website/docs/r/as_attachment.html.markdown
+++ b/website/docs/r/as_attachment.html.markdown
@@ -14,8 +14,8 @@ Provides a resource to attach or detach CVM instances to a specified scaling gro
 
 ```hcl
 resource "tencentcloud_as_attachment" "attachment" {
-  scaling_group_id           = "sg-afasfa"
-  instance_ids               = ["ins-01", "ins-02"]
+  scaling_group_id = "sg-afasfa"
+  instance_ids     = ["ins-01", "ins-02"]
 }
 ```
 

--- a/website/docs/r/as_lifecycle_hook.html.markdown
+++ b/website/docs/r/as_lifecycle_hook.html.markdown
@@ -14,14 +14,14 @@ Provides a resource for an AS (Auto scaling) lifecycle hook.
 
 ```hcl
 resource "tencentcloud_as_lifecycle_hook" "lifecycle_hook" {
-	scaling_group_id = "sg-12af45"
-	lifecycle_hook_name = "tf-as-lifecycle-hook"
-	lifecycle_transition = "INSTANCE_LAUNCHING"
-	default_result = "CONTINUE"
-	heartbeat_timeout = 500
-	notification_metadata = "tf test"
-	notification_target_type = "CMQ_QUEUE"
-	notification_queue_name = "lifcyclehook"
+  scaling_group_id         = "sg-12af45"
+  lifecycle_hook_name      = "tf-as-lifecycle-hook"
+  lifecycle_transition     = "INSTANCE_LAUNCHING"
+  default_result           = "CONTINUE"
+  heartbeat_timeout        = 500
+  notification_metadata    = "tf test"
+  notification_target_type = "CMQ_QUEUE"
+  notification_queue_name  = "lifcyclehook"
 }
 ```
 

--- a/website/docs/r/as_notification.html.markdown
+++ b/website/docs/r/as_notification.html.markdown
@@ -14,9 +14,9 @@ Provides a resource for an AS (Auto scaling) notification.
 
 ```hcl
 resource "tencentcloud_as_notification" "as_notification" {
-  scaling_group_id              = "sg-12af45"
-  notification_type             = ["SCALE_OUT_FAILED", "SCALE_IN_SUCCESSFUL", "SCALE_IN_FAILED", "REPLACE_UNHEALTHY_INSTANCE_FAILED"]
-  notification_user_group_ids   = ["76955"]
+  scaling_group_id            = "sg-12af45"
+  notification_type           = ["SCALE_OUT_FAILED", "SCALE_IN_SUCCESSFUL", "SCALE_IN_FAILED", "REPLACE_UNHEALTHY_INSTANCE_FAILED"]
+  notification_user_group_ids = ["76955"]
 }
 ```
 

--- a/website/docs/r/as_scaling_config.html.markdown
+++ b/website/docs/r/as_scaling_config.html.markdown
@@ -14,26 +14,26 @@ Provides a resource to create a configuration for an AS (Auto scaling) instance.
 
 ```hcl
 resource "tencentcloud_as_scaling_config" "launch_configuration" {
-	configuration_name = "launch-configuration"
-	image_id = "img-9qabwvbn"
-	instance_types = ["SA1.SMALL1"]
-	project_id = 0
-	system_disk_type = "CLOUD_PREMIUM"
-	system_disk_size = "50"
-	data_disk = {
-		disk_type = "CLOUD_PREMIUM"
-		disk_size = 50
-	}
-	internet_charge_type = "TRAFFIC_POSTPAID_BY_HOUR"
-	internet_max_bandwidth_out = 10
-	public_ip_assigned = true
-	password = "test123#"
-	enhanced_security_service = false
-	enhanced_monitor_service = false
-	user_data = "dGVzdA=="
-	instance_tags = {
-		tag = "as"
-	}
+  configuration_name = "launch-configuration"
+  image_id           = "img-9qabwvbn"
+  instance_types     = ["SA1.SMALL1"]
+  project_id         = 0
+  system_disk_type   = "CLOUD_PREMIUM"
+  system_disk_size   = "50"
+  data_disk = {
+    disk_type = "CLOUD_PREMIUM"
+    disk_size = 50
+  }
+  internet_charge_type       = "TRAFFIC_POSTPAID_BY_HOUR"
+  internet_max_bandwidth_out = 10
+  public_ip_assigned         = true
+  password                   = "test123#"
+  enhanced_security_service  = false
+  enhanced_monitor_service   = false
+  user_data                  = "dGVzdA=="
+  instance_tags = {
+    tag = "as"
+  }
 }
 ```
 

--- a/website/docs/r/as_scaling_group.html.markdown
+++ b/website/docs/r/as_scaling_group.html.markdown
@@ -14,17 +14,17 @@ Provides a resource to create a group of AS (Auto scaling) instances.
 
 ```hcl
 resource "tencentcloud_as_scaling_group" "scaling_group" {
-	scaling_group_name = "tf-as-scaling-group"
-	configuration_id = "asc-oqio4yyj"
-	max_size = 1
-	min_size = 0
-	vpc_id = "vpc-3efmz0z"
-	subnet_ids = ["subnet-mc3egos"]
-	project_id = 0
-	default_cooldown = 400
-	desired_capacity = 1
-	termination_policies = ["NEWEST_INSTANCE"]
-	retry_policy = "INCREMENTAL_INTERVALS"
+  scaling_group_name   = "tf-as-scaling-group"
+  configuration_id     = "asc-oqio4yyj"
+  max_size             = 1
+  min_size             = 0
+  vpc_id               = "vpc-3efmz0z"
+  subnet_ids           = ["subnet-mc3egos"]
+  project_id           = 0
+  default_cooldown     = 400
+  desired_capacity     = 1
+  termination_policies = ["NEWEST_INSTANCE"]
+  retry_policy         = "INCREMENTAL_INTERVALS"
 }
 ```
 

--- a/website/docs/r/as_scaling_policy.html.markdown
+++ b/website/docs/r/as_scaling_policy.html.markdown
@@ -14,17 +14,17 @@ Provides a resource for an AS (Auto scaling) policy.
 
 ```hcl
 resource "tencentcloud_as_scaling_policy" "scaling_policy" {
-	scaling_group_id = "asg-n32ymck2"
-	policy_name = "tf-as-scaling-policy"
-	adjustment_type = "EXACT_CAPACITY"
-	adjustment_value = 0
-	comparison_operator = "GREATER_THAN"
-	metric_name = "CPU_UTILIZATION"
-	threshold = 80
-	period = 300
-	continuous_time = 10
-	statistic = "AVERAGE"
-	cooldown = 360
+  scaling_group_id    = "asg-n32ymck2"
+  policy_name         = "tf-as-scaling-policy"
+  adjustment_type     = "EXACT_CAPACITY"
+  adjustment_value    = 0
+  comparison_operator = "GREATER_THAN"
+  metric_name         = "CPU_UTILIZATION"
+  threshold           = 80
+  period              = 300
+  continuous_time     = 10
+  statistic           = "AVERAGE"
+  cooldown            = 360
 }
 ```
 

--- a/website/docs/r/as_schedule.html.markdown
+++ b/website/docs/r/as_schedule.html.markdown
@@ -14,14 +14,14 @@ Provides a resource for an AS (Auto scaling) schedule.
 
 ```hcl
 resource "tencentcloud_as_schedule" "schedule" {
-	scaling_group_id = "sg-12af45"
-	schedule_action_name = "tf-as-schedule"
-	max_size = 10
-	min_size = 0
-	desired_capacity = 0
-	start_time = "2019-01-01T00:00:00+08:00"
-	end_time = "2019-12-01T00:00:00+08:00"
-	recurrence = "0 0 * * *"
+  scaling_group_id     = "sg-12af45"
+  schedule_action_name = "tf-as-schedule"
+  max_size             = 10
+  min_size             = 0
+  desired_capacity     = 0
+  start_time           = "2019-01-01T00:00:00+08:00"
+  end_time             = "2019-12-01T00:00:00+08:00"
+  recurrence           = "0 0 * * *"
 }
 ```
 

--- a/website/docs/r/cbs_snapshot.html.markdown
+++ b/website/docs/r/cbs_snapshot.html.markdown
@@ -14,8 +14,8 @@ Provide a resource to create a CBS snapshot.
 
 ```hcl
 resource "tencentcloud_cbs_snapshot" "snapshot" {
-        snapshot_name = "unnamed"
-        storage_id   = "disk-kdt0sq6m"
+  snapshot_name = "unnamed"
+  storage_id    = "disk-kdt0sq6m"
 }
 ```
 

--- a/website/docs/r/cbs_snapshot_policy.html.markdown
+++ b/website/docs/r/cbs_snapshot_policy.html.markdown
@@ -14,10 +14,10 @@ Provides a snapshot policy resource.
 
 ```hcl
 resource "tencentcloud-cbs_snapshot_policy" "snapshot_policy" {
-	snapshot_policy_name  = "mysnapshotpolicyname"
-	repeat_weekdays = [1, 4]
-	repeat_hours = [1]
-	retention_days = 7
+  snapshot_policy_name = "mysnapshotpolicyname"
+  repeat_weekdays      = [1, 4]
+  repeat_hours         = [1]
+  retention_days       = 7
 }
 ```
 

--- a/website/docs/r/cbs_storage.html.markdown
+++ b/website/docs/r/cbs_storage.html.markdown
@@ -14,15 +14,15 @@ Provide a resource to create a CBS.
 
 ```hcl
 resource "tencentcloud_cbs_storage" "storage" {
-        storage_name      = "mystorage"
-        storage_type      = "CLOUD_SSD"
-        storage_size      = "50"
-        availability_zone = "ap-guangzhou-3"
-		project_id        = 0
-		encrypt = false
-		tags = {
-			test = "tf"
-		}
+  storage_name      = "mystorage"
+  storage_type      = "CLOUD_SSD"
+  storage_size      = "50"
+  availability_zone = "ap-guangzhou-3"
+  project_id        = 0
+  encrypt           = false
+  tags = {
+    test = "tf"
+  }
 }
 ```
 

--- a/website/docs/r/cbs_storage_attachment.html.markdown
+++ b/website/docs/r/cbs_storage_attachment.html.markdown
@@ -14,8 +14,8 @@ Provides a CBS storage attachment resource.
 
 ```hcl
 resource "tencentcloud_cbs_storage_attachment" "attachment" {
-        storage_id  = "disk-kdt0sq6m"
-        instance_id = "ins-jqlegd42"
+  storage_id  = "disk-kdt0sq6m"
+  instance_id = "ins-jqlegd42"
 }
 ```
 

--- a/website/docs/r/ccn.html.markdown
+++ b/website/docs/r/ccn.html.markdown
@@ -13,10 +13,10 @@ Provides a resource to create a CCN instance.
 ## Example Usage
 
 ```hcl
-resource "tencentcloud_ccn" "main"{
-	name ="ci-temp-test-ccn"
-	description="ci-temp-test-ccn-des"
-	qos ="AG"
+resource "tencentcloud_ccn" "main" {
+  name        = "ci-temp-test-ccn"
+  description = "ci-temp-test-ccn-des"
+  qos         = "AG"
 }
 ```
 

--- a/website/docs/r/ccn_attachment.html.markdown
+++ b/website/docs/r/ccn_attachment.html.markdown
@@ -14,27 +14,27 @@ Provides a CCN attaching resource.
 
 ```hcl
 variable "region" {
-    default = "ap-guangzhou"
+  default = "ap-guangzhou"
 }
 
-resource  "tencentcloud_vpc"   "vpc"  {
-    name = "ci-temp-test-vpc"
-    cidr_block = "10.0.0.0/16"
-    dns_servers=["119.29.29.29","8.8.8.8"]
-    is_multicast=false
+resource "tencentcloud_vpc" "vpc" {
+  name         = "ci-temp-test-vpc"
+  cidr_block   = "10.0.0.0/16"
+  dns_servers  = ["119.29.29.29", "8.8.8.8"]
+  is_multicast = false
 }
 
-resource "tencentcloud_ccn" "main"{
-	name ="ci-temp-test-ccn"
-	description="ci-temp-test-ccn-des"
-	qos ="AG"
+resource "tencentcloud_ccn" "main" {
+  name        = "ci-temp-test-ccn"
+  description = "ci-temp-test-ccn-des"
+  qos         = "AG"
 }
 
-resource "tencentcloud_ccn_attachment" "attachment"{
-	ccn_id = "${tencentcloud_ccn.main.id}"
-	instance_type ="VPC"
-	instance_id ="${tencentcloud_vpc.vpc.id}"
-	instance_region="${var.region}"
+resource "tencentcloud_ccn_attachment" "attachment" {
+  ccn_id          = "${tencentcloud_ccn.main.id}"
+  instance_type   = "VPC"
+  instance_id     = "${tencentcloud_vpc.vpc.id}"
+  instance_region = "${var.region}"
 }
 ```
 

--- a/website/docs/r/ccn_bandwidth_limit.html.markdown
+++ b/website/docs/r/ccn_bandwidth_limit.html.markdown
@@ -14,18 +14,18 @@ Provides a resource to limit CCN bandwidth.
 
 ```hcl
 variable "other_region1" {
-    default = "ap-shanghai"
+  default = "ap-shanghai"
 }
-resource "tencentcloud_ccn" "main"{
-	name ="ci-temp-test-ccn"
-	description="ci-temp-test-ccn-des"
-	qos ="AG"
+resource "tencentcloud_ccn" "main" {
+  name        = "ci-temp-test-ccn"
+  description = "ci-temp-test-ccn-des"
+  qos         = "AG"
 }
 
 resource "tencentcloud_ccn_bandwidth_limit" "limit1" {
-	ccn_id ="${tencentcloud_ccn.main.id}"
-	region ="${var.other_region1}"
-	bandwidth_limit = 500
+  ccn_id          = "${tencentcloud_ccn.main.id}"
+  region          = "${var.other_region1}"
+  bandwidth_limit = 500
 }
 ```
 

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -16,31 +16,31 @@ Basic Usage
 
 ```hcl
 resource "tencentcloud_container_cluster" "foo" {
- cluster_name = "terraform-acc-test"
- cpu    = 1
- mem    = 1
- os_name   = "ubuntu16.04.1 LTSx86_64"
- bandwidth  = 1
- bandwidth_type = "PayByHour"
- require_wan_ip   = 1
- subnet_id  = "subnet-abcdabc"
- is_vpc_gateway = 0
- storage_size = 0
- root_size  = 50
- goods_num  = 1
- password  = "Admin12345678"
- vpc_id   = "vpc-abcdabc"
- cluster_cidr = "10.0.2.0/24"
- ignore_cluster_cidr_conflict = 0
- cvm_type  = "PayByHour"
- cluster_desc = "foofoofoo"
- period   = 1
- zone_id   = 100004
- instance_type = "S2.SMALL1"
- mount_target = ""
- docker_graph_path = ""
- instance_name = "bar-vm"
- cluster_version = "1.7.8"
+  cluster_name                 = "terraform-acc-test"
+  cpu                          = 1
+  mem                          = 1
+  os_name                      = "ubuntu16.04.1 LTSx86_64"
+  bandwidth                    = 1
+  bandwidth_type               = "PayByHour"
+  require_wan_ip               = 1
+  subnet_id                    = "subnet-abcdabc"
+  is_vpc_gateway               = 0
+  storage_size                 = 0
+  root_size                    = 50
+  goods_num                    = 1
+  password                     = "Admin12345678"
+  vpc_id                       = "vpc-abcdabc"
+  cluster_cidr                 = "10.0.2.0/24"
+  ignore_cluster_cidr_conflict = 0
+  cvm_type                     = "PayByHour"
+  cluster_desc                 = "foofoofoo"
+  period                       = 1
+  zone_id                      = 100004
+  instance_type                = "S2.SMALL1"
+  mount_target                 = ""
+  docker_graph_path            = ""
+  instance_name                = "bar-vm"
+  cluster_version              = "1.7.8"
 }
 ```
 

--- a/website/docs/r/container_cluster_instance.html.markdown
+++ b/website/docs/r/container_cluster_instance.html.markdown
@@ -16,23 +16,23 @@ Basic Usage
 
 ```hcl
 resource "tencentcloud_container_cluster_instance" "bar_instance" {
- cpu    = 1
- mem    = 1
- bandwidth  = 1
- bandwidth_type = "PayByHour"
- require_wan_ip   = 1
- is_vpc_gateway = 0
- storage_size = 10
- root_size  = 50
- password  = "Admin12345678"
- cvm_type  = "PayByMonth"
- period   = 1
- zone_id   = 100004
- instance_type = "CVM.S2"
- mount_target = "/data"
- docker_graph_path = ""
- subnet_id  = "subnet-abcdedf"
- cluster_id = "cls-abcdef"
+  cpu               = 1
+  mem               = 1
+  bandwidth         = 1
+  bandwidth_type    = "PayByHour"
+  require_wan_ip    = 1
+  is_vpc_gateway    = 0
+  storage_size      = 10
+  root_size         = 50
+  password          = "Admin12345678"
+  cvm_type          = "PayByMonth"
+  period            = 1
+  zone_id           = 100004
+  instance_type     = "CVM.S2"
+  mount_target      = "/data"
+  docker_graph_path = ""
+  subnet_id         = "subnet-abcdedf"
+  cluster_id        = "cls-abcdef"
 }
 ```
 

--- a/website/docs/r/cos_bucket_object.html.markdown
+++ b/website/docs/r/cos_bucket_object.html.markdown
@@ -27,12 +27,12 @@ Uploading a content to a bucket
 ```hcl
 resource "tencentcloud_cos_bucket" "mycos" {
   bucket = "mycos-1258798060"
-  acl = "public-read"
+  acl    = "public-read"
 }
 
 resource "tencentcloud_cos_bucket_object" "myobject" {
-  bucket = "${tencentcloud_cos_bucket.mycos.bucket}"
-  key    = "new_object_key"
+  bucket  = "${tencentcloud_cos_bucket.mycos.bucket}"
+  key     = "new_object_key"
   content = "the content that you want to upload."
 }
 ```

--- a/website/docs/r/dnat.html.markdown
+++ b/website/docs/r/dnat.html.markdown
@@ -46,10 +46,10 @@ resource "tencentcloud_eip" "eip_test_dnat" {
 
 # Create NAT Gateway
 resource "tencentcloud_nat_gateway" "my_nat" {
-  vpc_id           = "${tencentcloud_vpc.main.id}"
-  name             = "terraform test"
-  max_concurrent   = 3000000
-  bandwidth        = 500
+  vpc_id         = "${tencentcloud_vpc.main.id}"
+  name           = "terraform test"
+  max_concurrent = 3000000
+  bandwidth      = 500
   assigned_eip_set = [
     "${tencentcloud_eip.eip_dev_dnat.public_ip}",
     "${tencentcloud_eip.eip_test_dnat.public_ip}",

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -16,7 +16,7 @@ Basic Usage
 
 ```hcl
 resource "tencentcloud_eip" "foo" {
-	name = "awesome_gateway_ip"
+  name = "awesome_gateway_ip"
 }
 ```
 

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -18,8 +18,8 @@ Basic Usage
 
 ```hcl
 resource "tencentcloud_eip_association" "foo" {
-	eip_id = "eip-xxxxxx"
-	instance_id = "ins-xxxxxx"
+  eip_id      = "eip-xxxxxx"
+  instance_id = "ins-xxxxxx"
 }
 ```
 
@@ -27,9 +27,9 @@ or
 
 ```hcl
 resource "tencentcloud_eip_association" "bar" {
-	eip_id = "eip-xxxxxx"
-	network_interface_id = "eni-xxxxxx"
-	private_ip = "10.0.1.22"
+  eip_id               = "eip-xxxxxx"
+  network_interface_id = "eni-xxxxxx"
+  private_ip           = "10.0.1.22"
 }
 ```
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -66,7 +66,7 @@ resource "tencentcloud_vpc" "app" {
   name       = "awesome_app_vpc"
 }
 resource "tencentcloud_subnet" "app" {
-  vpc_id = "${tencentcloud_vpc.app.id}"
+  vpc_id            = "${tencentcloud_vpc.app.id}"
   availability_zone = "${data.tencentcloud_availability_zones.my_favorate_zones.zones.0.name}"
   name              = "awesome_app_subnet"
   cidr_block        = "10.0.1.0/24"
@@ -81,17 +81,17 @@ resource "tencentcloud_instance" "my_awesome_app" {
   key_name          = "${tencentcloud_key_pair.random_key.id}"
   hostname          = "awesome_app"
   project_id        = 0
-  tags              = {
+  tags = {
     tagKey = "tagValue"
   }
 
   security_groups = [
     "${tencentcloud_security_group.app.id}",
   ]
-  
+
   vpc_id    = "${tencentcloud_vpc.app.id}"
   subnet_id = "${tencentcloud_subnet.app.id}"
-  
+
   internet_max_bandwidth_out = 20
   count                      = 10
 }

--- a/website/docs/r/key_pair.html.markdown
+++ b/website/docs/r/key_pair.html.markdown
@@ -16,7 +16,7 @@ Basic Usage
 
 ```hcl
 resource "tencentcloud_key_pair" "foo" {
-  key_name = "from_terraform_public_key"
+  key_name   = "from_terraform_public_key"
   public_key = "ssh-rsa AAAAB3NzaSuperLongString foo@bar"
 }
 ```

--- a/website/docs/r/mysql_account.html.markdown
+++ b/website/docs/r/mysql_account.html.markdown
@@ -14,9 +14,9 @@ Provides a MySQL account resource for database management. A MySQL instance supp
 
 ```hcl
 resource "tencentcloud_mysql_account" "default" {
-  mysql_id = "my-test-database"
-  name = "tf_account"
-  password = "********"
+  mysql_id    = "my-test-database"
+  name        = "tf_account"
+  password    = "********"
   description = "My test account"
 }
 ```

--- a/website/docs/r/mysql_account_privilege.html.markdown
+++ b/website/docs/r/mysql_account_privilege.html.markdown
@@ -14,9 +14,9 @@ Provides a mysql account privilege resource to grant different access privilege 
 
 ```hcl
 resource "tencentcloud_mysql_account_privilege" "default" {
-  mysql_id = "my-test-database"
-  account_name= "tf_account"
-  privileges = ["SELECT"]
+  mysql_id       = "my-test-database"
+  account_name   = "tf_account"
+  privileges     = ["SELECT"]
   database_names = ["instance.name"]
 }
 ```

--- a/website/docs/r/mysql_backup_policy.html.markdown
+++ b/website/docs/r/mysql_backup_policy.html.markdown
@@ -14,10 +14,10 @@ Provides a mysql policy resource to create a backup policy.
 
 ```hcl
 resource "tencentcloud_mysql_backup_policy" "default" {
-  mysql_id = "cdb-dnqksd9f"
+  mysql_id         = "cdb-dnqksd9f"
   retention_period = 7
-  backup_model = "logical"
-  backup_time ="02:00–06:00"
+  backup_model     = "logical"
+  backup_time      = "02:00–06:00"
 }
 ```
 

--- a/website/docs/r/mysql_instance.html.markdown
+++ b/website/docs/r/mysql_instance.html.markdown
@@ -17,26 +17,26 @@ Provides a mysql instance resource to create master database instances.
 ```hcl
 resource "tencentcloud_mysql_instance" "default" {
   internet_service = 1
-  engine_version = "5.7"
+  engine_version   = "5.7"
   parameters = {
     max_connections = "1000"
   }
-  root_password = "********"
+  root_password     = "********"
   slave_deploy_mode = 0
-  first_slave_zone = "ap-guangzhou-4"
+  first_slave_zone  = "ap-guangzhou-4"
   second_slave_zone = "ap-guangzhou-4"
-  slave_sync_mode = 1
+  slave_sync_mode   = 1
   availability_zone = "ap-guangzhou-4"
-  project_id = 201901010001
-  instance_name = "myTestMysql"
-  mem_size = 128000
-  volume_size = 250
-  vpc_id = "vpc-12mt3l31"
-  subnet_id = "subnet-9uivyb1g"
-  intranet_port = 3306
-  security_groups = ["sg-ot8eclwz"]
+  project_id        = 201901010001
+  instance_name     = "myTestMysql"
+  mem_size          = 128000
+  volume_size       = 250
+  vpc_id            = "vpc-12mt3l31"
+  subnet_id         = "subnet-9uivyb1g"
+  intranet_port     = 3306
+  security_groups   = ["sg-ot8eclwz"]
   tags = {
-    name ="test"
+    name = "test"
   }
 }
 ```

--- a/website/docs/r/mysql_readonly_instance.html.markdown
+++ b/website/docs/r/mysql_readonly_instance.html.markdown
@@ -17,15 +17,15 @@ Provides a mysql instance resource to create read-only database instances.
 ```hcl
 resource "tencentcloud_mysql_readonly_instance" "default" {
   master_instance_id = "cdb-dnqksd9f"
-  instance_name ="myTestMysql"
-  mem_size = 128000
-  volume_size = 255
-  vpc_id = "vpc-12mt3l31"
-  subnet_id = "subnet-9uivyb1g"
-  intranet_port = 3306
-  security_groups = ["sg-ot8eclwz"]
+  instance_name      = "myTestMysql"
+  mem_size           = 128000
+  volume_size        = 255
+  vpc_id             = "vpc-12mt3l31"
+  subnet_id          = "subnet-9uivyb1g"
+  intranet_port      = 3306
+  security_groups    = ["sg-ot8eclwz"]
   tags = {
-    name ="test"
+    name = "test"
   }
 }
 ```

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -30,10 +30,10 @@ resource "tencentcloud_eip" "eip_test_dnat" {
 
 # Create NAT Gateway
 resource "tencentcloud_nat_gateway" "my_nat" {
-  vpc_id           = "${tencentcloud_vpc.main.id}"
-  name             = "terraform test"
-  max_concurrent   = 3000000
-  bandwidth        = 500
+  vpc_id         = "${tencentcloud_vpc.main.id}"
+  name           = "terraform test"
+  max_concurrent = 3000000
+  bandwidth      = 500
   assigned_eip_set = [
     "${tencentcloud_eip.eip_dev_dnat.public_ip}",
     "${tencentcloud_eip.eip_test_dnat.public_ip}",

--- a/website/docs/r/redis_backup_config.html.markdown
+++ b/website/docs/r/redis_backup_config.html.markdown
@@ -14,9 +14,9 @@ Use this data source to query which instance types of Redis are available in a s
 
 ```hcl
 resource "tencentcloud_redis_backup_config" "redislab" {
-  redis_id       = "crs-7yl0q0dd"
-  backup_time    = "04:00-05:00"
-  backup_period  = ["Monday"]
+  redis_id      = "crs-7yl0q0dd"
+  backup_time   = "04:00-05:00"
+  backup_period = ["Monday"]
 }
 ```
 

--- a/website/docs/r/redis_instance.html.markdown
+++ b/website/docs/r/redis_instance.html.markdown
@@ -13,13 +13,13 @@ Provides a resource to create a Redis instance and set its attributes.
 ## Example Usage
 
 ```hcl
-resource "tencentcloud_redis_instance" "redis_instance_test"{
-	availability_zone="ap-hongkong-3"
-	type="master_slave_redis"
-	password="test12345789"
-	mem_size=8192
-	name="terrform_test"
-	port=6379
+resource "tencentcloud_redis_instance" "redis_instance_test" {
+  availability_zone = "ap-hongkong-3"
+  type              = "master_slave_redis"
+  password          = "test12345789"
+  mem_size          = 8192
+  name              = "terrform_test"
+  port              = 6379
 }
 ```
 

--- a/website/docs/r/route_entry.html.markdown
+++ b/website/docs/r/route_entry.html.markdown
@@ -19,7 +19,7 @@ Basic usage:
 
 ```hcl
 resource "tencentcloud_vpc" "main" {
-  name       = "Used to test the routing entry" 
+  name       = "Used to test the routing entry"
   cidr_block = "10.4.0.0/16"
 }
 

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -14,13 +14,13 @@ Provides a resource to create a VPC routing table.
 
 ```hcl
 resource "tencentcloud_vpc" "foo" {
-    name = "ci-temp-test"
-    cidr_block = "10.0.0.0/16"
+  name       = "ci-temp-test"
+  cidr_block = "10.0.0.0/16"
 }
 
 resource "tencentcloud_route_table" "foo" {
-   vpc_id = "${tencentcloud_vpc.foo.id}"
-   name = "ci-temp-test-rt"
+  vpc_id = "${tencentcloud_vpc.foo.id}"
+  name   = "ci-temp-test-rt"
 }
 ```
 

--- a/website/docs/r/route_table_entry.html.markdown
+++ b/website/docs/r/route_table_entry.html.markdown
@@ -18,7 +18,7 @@ variable "availability_zone" {
 }
 
 resource "tencentcloud_vpc" "foo" {
-  name = "ci-temp-test"
+  name       = "ci-temp-test"
   cidr_block = "10.0.0.0/16"
 }
 
@@ -27,20 +27,20 @@ resource "tencentcloud_subnet" "foo" {
   name              = "terraform test subnet"
   cidr_block        = "10.0.12.0/24"
   availability_zone = "${var.availability_zone}"
-  route_table_id = "${tencentcloud_route_table.foo.id}"
+  route_table_id    = "${tencentcloud_route_table.foo.id}"
 }
 
 resource "tencentcloud_route_table" "foo" {
   vpc_id = "${tencentcloud_vpc.foo.id}"
-  name = "ci-temp-test-rt"
+  name   = "ci-temp-test-rt"
 }
 
 resource "tencentcloud_route_table_entry" "instance" {
-  route_table_id = "${tencentcloud_route_table.foo.id}"
-  destination_cidr_block     = "10.4.4.0/24"
-  next_type      = "EIP"
-  next_hub       = "0"
-  description    = "ci-test-route-table-entry"
+  route_table_id         = "${tencentcloud_route_table.foo.id}"
+  destination_cidr_block = "10.4.4.0/24"
+  next_type              = "EIP"
+  next_hub               = "0"
+  description            = "ci-test-route-table-entry"
 }
 ```
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -14,19 +14,19 @@ Provide a resource to create a VPC subnet.
 
 ```hcl
 variable "availability_zone" {
-	default = "ap-guangzhou-3"
+  default = "ap-guangzhou-3"
 }
 
 resource "tencentcloud_vpc" "foo" {
-    name="guagua-ci-temp-test"
-    cidr_block="10.0.0.0/16"
+  name       = "guagua-ci-temp-test"
+  cidr_block = "10.0.0.0/16"
 }
 resource "tencentcloud_subnet" "subnet" {
-	availability_zone="${var.availability_zone}"
-	name="guagua-ci-temp-test"
-	vpc_id="${tencentcloud_vpc.foo.id}"
-	cidr_block="10.0.20.0/28"
-	is_multicast=false
+  availability_zone = "${var.availability_zone}"
+  name              = "guagua-ci-temp-test"
+  vpc_id            = "${tencentcloud_vpc.foo.id}"
+  cidr_block        = "10.0.20.0/28"
+  is_multicast      = false
 }
 ```
 

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -14,10 +14,10 @@ Provide a resource to create a VPC.
 
 ```hcl
 resource "tencentcloud_vpc" "foo" {
-    name = "ci-temp-test-updated"
-    cidr_block = "10.0.0.0/16"
-	dns_servers=["119.29.29.29","8.8.8.8"]
-	is_multicast=false
+  name         = "ci-temp-test-updated"
+  cidr_block   = "10.0.0.0/16"
+  dns_servers  = ["119.29.29.29", "8.8.8.8"]
+  is_multicast = false
 }
 ```
 


### PR DESCRIPTION
Along with the release of Terraform v0.12, Terraform also introduces the officially recommended [Idiomatic Style Conventions](https://www.terraform.io/docs/configuration/style.html) for HCL languages. For better readability of the docs, the inline HCLs in docs should also follow that rule. 

This PR is trying to use a tool I developed to convert all the existing inline HCL codes into the canonical format.

Signed-off-by: imjoey <majunjiev@gmail.com>
