### PR TITLE
Readonly mysql  instance can't  be released immediately.

### DIFF
--- a/tencentcloud/extension_mysql.go
+++ b/tencentcloud/extension_mysql.go
@@ -15,6 +15,10 @@ const (
 	MYSQL_STATUS_RUNNING   = 1
 	MYSQL_STATUS_ISOLATING = 4
 	MYSQL_STATUS_ISOLATED  = 5
+	//https://cloud.tencent.com/document/api/236/36197
+	//Internal business state , not public
+	MYSQL_STATUS_ISOLATED_1 = 6
+	MYSQL_STATUS_ISOLATED_2 = 7
 )
 
 //Async  task  status,  from  https://cloud.tencent.com/document/api/236/20410

--- a/tencentcloud/helper.go
+++ b/tencentcloud/helper.go
@@ -138,3 +138,7 @@ func intToPointer(i int) *uint64 {
 	u := uint64(i)
 	return &u
 }
+
+func uint64Pt(i uint64) *uint64 {
+	return &i
+}

--- a/tencentcloud/resource_tc_mysql_instance.go
+++ b/tencentcloud/resource_tc_mysql_instance.go
@@ -1,7 +1,7 @@
 /*
 Provides a mysql instance resource to create master database instances.
 
-~> **NOTE:** The terminate operation of mysql does NOT take effect immediately，maybe takes for several hours. so during that time, VPCs associated with that mysql instance can't be terminated also.
+~> **NOTE:** If this mysql has readonly instance, the terminate operation of the mysql does NOT take effect immediately，maybe takes for several hours. so during that time, VPCs associated with that mysql instance can't be terminated also.
 
 Example Usage
 
@@ -1212,8 +1212,8 @@ func resourceTencentCloudMysqlInstanceDelete(d *schema.ResourceData, meta interf
 	if hasDeleted {
 		return nil
 	}
-	if err!=nil{
-		return  err
+	if err != nil {
+		return err
 	}
 
 	err = mysqlService.OfflineIsolatedInstances(ctx, d.Id())
@@ -1223,7 +1223,6 @@ func resourceTencentCloudMysqlInstanceDelete(d *schema.ResourceData, meta interf
 
 	err = resource.Retry(20*time.Minute, func() *resource.RetryError {
 		mysqlInfo, err := mysqlService.DescribeIsolatedDBInstanceById(ctx, d.Id())
-
 		if err != nil {
 			if _, ok := err.(*errors.TencentCloudSDKError); !ok {
 				return resource.RetryableError(err)
@@ -1234,6 +1233,10 @@ func resourceTencentCloudMysqlInstanceDelete(d *schema.ResourceData, meta interf
 		if mysqlInfo == nil {
 			return nil
 		} else {
+			if mysqlInfo.RoGroups != nil && len(mysqlInfo.RoGroups) > 0 {
+				log.Printf("[WARN]this mysql has RoGroups , RoGroups is released asynchronously, and the bound resource is not now fully released now\n")
+				return nil
+			}
 			return resource.RetryableError(fmt.Errorf("after OfflineIsolatedInstances mysql Status is %d", *mysqlInfo.Status))
 		}
 	})

--- a/tencentcloud/resource_tc_mysql_readonly_instance.go
+++ b/tencentcloud/resource_tc_mysql_readonly_instance.go
@@ -1,7 +1,7 @@
 /*
 Provides a mysql instance resource to create read-only database instances.
 
-~> **NOTE:** The terminate operation of mysql does NOT take effect immediately，maybe takes for several hours. so during that time, VPCs associated with that mysql instance can't be terminated also.
+~> **NOTE:** The terminate operation of read only mysql does NOT take effect immediately，maybe takes for several hours. so during that time, VPCs associated with that mysql instance can't be terminated also.
 
 Example Usage
 
@@ -301,24 +301,10 @@ func resourceTencentCloudMysqlReadonlyInstanceDelete(d *schema.ResourceData, met
 		return err
 	}
 	err = mysqlService.OfflineIsolatedInstances(ctx, d.Id())
-	if err != nil {
-		return err
-	}
 
-	err = resource.Retry(20*time.Minute, func() *resource.RetryError {
-		mysqlInfo, err := mysqlService.DescribeIsolatedDBInstanceById(ctx, d.Id())
-		if err != nil {
-			if _, ok := err.(*errors.TencentCloudSDKError); !ok {
-				return resource.RetryableError(err)
-			} else {
-				return resource.NonRetryableError(err)
-			}
-		}
-		if mysqlInfo == nil {
-			return nil
-		} else {
-			return resource.RetryableError(fmt.Errorf("after OfflineIsolatedInstances mysql Status is %d", *mysqlInfo.Status))
-		}
-	})
+	if err == nil {
+		log.Printf("[WARN]this mysql is readonly instance, it is released asynchronously, and the bound resource is not now fully released now\n")
+	}
 	return err
+
 }

--- a/website/docs/r/mysql_instance.html.markdown
+++ b/website/docs/r/mysql_instance.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a mysql instance resource to create master database instances.
 
-~> **NOTE:** The terminate operation of mysql does NOT take effect immediately，maybe takes for several hours. so during that time, VPCs associated with that mysql instance can't be terminated also.
+~> **NOTE:** If this mysql has readonly instance, the terminate operation of the mysql does NOT take effect immediately，maybe takes for several hours. so during that time, VPCs associated with that mysql instance can't be terminated also.
 
 ## Example Usage
 

--- a/website/docs/r/mysql_readonly_instance.html.markdown
+++ b/website/docs/r/mysql_readonly_instance.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a mysql instance resource to create read-only database instances.
 
-~> **NOTE:** The terminate operation of mysql does NOT take effect immediately，maybe takes for several hours. so during that time, VPCs associated with that mysql instance can't be terminated also.
+~> **NOTE:** The terminate operation of read only mysql does NOT take effect immediately，maybe takes for several hours. so during that time, VPCs associated with that mysql instance can't be terminated also.
 
 ## Example Usage
 


### PR DESCRIPTION
If mysql has readonly instance or it is a readonly instance, it can't  be released immediately.
