### PR TITLE
fix cvm data disk missing computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.16.2 (Unreleased)
+
+BUG FIXIES:
+
+* resource/tencentcloud_instance: fixed cvm data disks missing computed.
+
 ## 1.16.1 (August 27, 2019)
 
 ENHANCEMENTS:

--- a/tencentcloud/resource_tc_instance.go
+++ b/tencentcloud/resource_tc_instance.go
@@ -245,6 +245,7 @@ func resourceTencentCloudInstance() *schema.Resource {
 				Type:        schema.TypeList,
 				MaxItems:    10,
 				Optional:    true,
+				Computed:    true,
 				Description: "Settings for data disk.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
This issue caused the cbs attach to fail