### PR TITLE
Miss argument availability_zone  causes  mysql  recreated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.20.0 (Unreleased)
 
 BUG FIXES:
-* Resource: `tencentcloud_mysql_instance`: default argument `availability_zone` causes the instance to be recreated.
+* Resource: `tencentcloud_mysql_instance`: miss argument `availability_zone` causes the instance to be recreated.
 
 ## 1.19.0 (September 19, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.20.0 (Unreleased)
+
+BUG FIXES:
+* Resource: `tencentcloud_mysql_instance`: default argument `availability_zone` causes the instance to be recreated.
+
 ## 1.19.0 (September 19, 2019)
 
 FEATURES:

--- a/tencentcloud/resource_tc_mysql_instance.go
+++ b/tencentcloud/resource_tc_mysql_instance.go
@@ -226,6 +226,7 @@ func resourceTencentCloudMysqlInstance() *schema.Resource {
 		"project_id": {
 			Type:        schema.TypeInt,
 			Optional:    true,
+			Default:     0,
 			Description: "Project ID, default value is 0.",
 		},
 

--- a/tencentcloud/resource_tc_mysql_instance.go
+++ b/tencentcloud/resource_tc_mysql_instance.go
@@ -185,6 +185,7 @@ func resourceTencentCloudMysqlInstance() *schema.Resource {
 			Type:        schema.TypeString,
 			ForceNew:    true,
 			Optional:    true,
+			Computed:    true,
 			Description: "Indicates which availability zone will be used.",
 		},
 		"root_password": {


### PR DESCRIPTION
Resource: `tencentcloud_mysql_instance`: miss argument `availability_zone` causes the instance to be recreated.