### PR TITLE
Fix gaap nil error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 ENHANCEMENTS:
 
 * Data Source: `tencentcloud_as_scaling_groups` add optional argument `tags` and attribute `tags` for `scaling_group_list`.
-* Data Source: `tencentcloud_gaap_http_domains` set response `certificate_id`, `client_certificate_id`, `realserver_auth`, `basic_auth` and `gaap_auth` default value when they are nil.
 * Resource: `tencentcloud_as_scaling_group` add optional argument `tags`.
+
+BUG FIXES:
+
+* Data Source: `tencentcloud_gaap_http_domains` set response `certificate_id`, `client_certificate_id`, `realserver_auth`, `basic_auth` and `gaap_auth` default value when they are nil.
 * Resource: `tencentcloud_gaap_http_domain` set response `certificate_id`, `client_certificate_id`, `realserver_auth`, `basic_auth` and `gaap_auth` default value when they are nil.
 
 ## 1.20.0 (September 24, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ENHANCEMENTS:
 
 * Data Source: `tencentcloud_as_scaling_groups` add optional argument `tags` and attribute `tags` for `scaling_group_list`.
+* Data Source: `tencentcloud_gaap_http_domains` set response `certificate_id`, `client_certificate_id`, `realserver_auth`, `basic_auth` and `gaap_auth` default value when they are nil.
 * Resource: `tencentcloud_as_scaling_group` add optional argument `tags`.
+* Resource: `tencentcloud_gaap_http_domain` set response `certificate_id`, `client_certificate_id`, `realserver_auth`, `basic_auth` and `gaap_auth` default value when they are nil.
 
 ## 1.20.0 (September 24, 2019)
 

--- a/tencentcloud/data_source_tc_gaap_http_domains.go
+++ b/tencentcloud/data_source_tc_gaap_http_domains.go
@@ -34,7 +34,6 @@ package tencentcloud
 
 import (
 	"context"
-	"errors"
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -143,27 +142,27 @@ func dataSourceTencentCloudGaapHttpDomainsRead(d *schema.ResourceData, m interfa
 	domains := make([]map[string]interface{}, 0, len(domainRules))
 	for _, dr := range domainRules {
 		if dr.CertificateId == nil {
-			return errors.New("domain certificate id is nil")
+			dr.CertificateId = stringToPointer("default")
 		}
 		if dr.ClientCertificateId == nil {
-			return errors.New("domain client certificate id is nil")
+			dr.ClientCertificateId = stringToPointer("default")
 		}
 		if dr.RealServerAuth == nil {
-			return errors.New("domain realserver auth is nil")
+			dr.RealServerAuth = int64ToPointer(0)
 		}
 		if dr.BasicAuth == nil {
-			return errors.New("domain basic auth is nil")
+			dr.BasicAuth = int64ToPointer(0)
 		}
 		if dr.GaapAuth == nil {
-			return errors.New("domain gaap auth is nil")
+			dr.GaapAuth = int64ToPointer(0)
 		}
 
 		ids = append(ids, *dr.Domain)
 
 		m := map[string]interface{}{
-			"domain":                *dr.Domain,
-			"certificate_id":        *dr.CertificateId,
-			"client_certificate_id": *dr.ClientCertificateId,
+			"domain":                dr.Domain,
+			"certificate_id":        dr.CertificateId,
+			"client_certificate_id": dr.ClientCertificateId,
 			"realserver_auth":       *dr.RealServerAuth == 1,
 			"basic_auth":            *dr.BasicAuth == 1,
 			"gaap_auth":             *dr.GaapAuth == 1,

--- a/tencentcloud/resource_tc_gaap_http_domain.go
+++ b/tencentcloud/resource_tc_gaap_http_domain.go
@@ -280,17 +280,17 @@ func resourceTencentCloudGaapHttpDomainRead(d *schema.ResourceData, m interface{
 	}
 
 	if httpDomain.CertificateId == nil {
-		return errors.New("domain certificate id is nil")
+		httpDomain.CertificateId = stringToPointer("default")
 	}
 	d.Set("certificate_id", httpDomain.CertificateId)
 
 	if httpDomain.ClientCertificateId == nil {
-		return errors.New("domain client certificate id is nil")
+		httpDomain.ClientCertificateId = stringToPointer("default")
 	}
 	d.Set("client_certificate_id", httpDomain.ClientCertificateId)
 
 	if httpDomain.BasicAuth == nil {
-		return errors.New("domain basic auth is nil")
+		httpDomain.BasicAuth = int64ToPointer(0)
 	}
 	d.Set("basic_auth", *httpDomain.BasicAuth == 1)
 
@@ -299,7 +299,7 @@ func resourceTencentCloudGaapHttpDomainRead(d *schema.ResourceData, m interface{
 	}
 
 	if httpDomain.RealServerAuth == nil {
-		return errors.New("domain realserver auth is nil")
+		httpDomain.RealServerAuth = int64ToPointer(0)
 	}
 	d.Set("realserver_auth", *httpDomain.RealServerAuth == 1)
 
@@ -311,7 +311,7 @@ func resourceTencentCloudGaapHttpDomainRead(d *schema.ResourceData, m interface{
 	}
 
 	if httpDomain.GaapAuth == nil {
-		return errors.New("domain gaap auth is nil")
+		httpDomain.GaapAuth = int64ToPointer(0)
 	}
 	d.Set("gaap_auth", *httpDomain.GaapAuth == 1)
 


### PR DESCRIPTION
gaap http_domain some attributes `certificate_id`, `client_certificate_id`, `realserver_auth`, `basic_auth` and `gaap_auth` sometimes return `null`, set them default value when they are `null` to avoid user can't `terraform refresh`