### PR TITLE
Fix type mismatch in sweepers

### DIFF
--- a/tencentcloud/resource_tc_as_scaling_group_test.go
+++ b/tencentcloud/resource_tc_as_scaling_group_test.go
@@ -26,7 +26,7 @@ func testSweepAsScalingGroups(region string) error {
 	if err != nil {
 		return fmt.Errorf("getting tencentcloud client error: %s", err.Error())
 	}
-	client := sharedClient.(TencentCloudClient)
+	client := sharedClient.(*TencentCloudClient)
 
 	asService := AsService{
 		client: client.apiV3Conn,

--- a/tencentcloud/resource_tc_cos_bucket_test.go
+++ b/tencentcloud/resource_tc_cos_bucket_test.go
@@ -26,7 +26,7 @@ func testSweepCosBuckets(region string) error {
 	if err != nil {
 		return fmt.Errorf("getting tencentcloud client error: %s", err.Error())
 	}
-	client := sharedClient.(TencentCloudClient)
+	client := sharedClient.(*TencentCloudClient)
 
 	cosService := CosService{
 		client: client.apiV3Conn,


### PR DESCRIPTION
The Pre-Sweeper build step on TC was failing due to a panic. Fix the type mismatch in the sweeper functions that caused it.