### PR TITLE
data source support default vpc & subnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.28.1 (Unreleased)
+
+ENHANCEMENTS:
+* Data Source: `tencentcloud_vpc_instances` add new optional argument `is_default`.
+* Data Source: `tencentcloud_vpc_subnets` add new output argument `availability_zone`,`is_default`.
+
 ## 1.28.0 (December 25, 2019)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ENHANCEMENTS:
 * Data Source: `tencentcloud_vpc_instances` add new optional argument `is_default`.
-* Data Source: `tencentcloud_vpc_subnets` add new output argument `availability_zone`,`is_default`.
+* Data Source: `tencentcloud_vpc_subnets` add new optional argument `availability_zone`,`is_default`.
 
 ## 1.28.0 (December 25, 2019)
 

--- a/tencentcloud/data_source_tc_subnet.go
+++ b/tencentcloud/data_source_tc_subnet.go
@@ -90,7 +90,7 @@ func dataSourceTencentCloudSubnetRead(d *schema.ResourceData, meta interface{}) 
 	vpcId := d.Get("vpc_id").(string)
 	subnetId := d.Get("subnet_id").(string)
 
-	infos, err := vpcService.DescribeSubnets(ctx, subnetId, vpcId, "", "", map[string]string{},nil)
+	infos, err := vpcService.DescribeSubnets(ctx, subnetId, vpcId, "", "", map[string]string{}, nil)
 	if err != nil {
 		return err
 	}

--- a/tencentcloud/data_source_tc_subnet.go
+++ b/tencentcloud/data_source_tc_subnet.go
@@ -90,7 +90,7 @@ func dataSourceTencentCloudSubnetRead(d *schema.ResourceData, meta interface{}) 
 	vpcId := d.Get("vpc_id").(string)
 	subnetId := d.Get("subnet_id").(string)
 
-	infos, err := vpcService.DescribeSubnets(ctx, subnetId, vpcId, "", "", map[string]string{})
+	infos, err := vpcService.DescribeSubnets(ctx, subnetId, vpcId, "", "", map[string]string{},nil)
 	if err != nil {
 		return err
 	}

--- a/tencentcloud/data_source_tc_vpc.go
+++ b/tencentcloud/data_source_tc_vpc.go
@@ -92,7 +92,7 @@ func dataSourceTencentCloudVpcRead(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	var vpcInfos, err = service.DescribeVpcs(ctx, vpcId, name, map[string]string{})
+	var vpcInfos, err = service.DescribeVpcs(ctx, vpcId, name, map[string]string{},nil)
 	if err != nil {
 		return err
 	}

--- a/tencentcloud/data_source_tc_vpc.go
+++ b/tencentcloud/data_source_tc_vpc.go
@@ -92,7 +92,7 @@ func dataSourceTencentCloudVpcRead(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	var vpcInfos, err = service.DescribeVpcs(ctx, vpcId, name, map[string]string{},nil)
+	var vpcInfos, err = service.DescribeVpcs(ctx, vpcId, name, map[string]string{}, nil)
 	if err != nil {
 		return err
 	}

--- a/tencentcloud/resource_tc_kubernetes_as_scaling_group_test.go
+++ b/tencentcloud/resource_tc_kubernetes_as_scaling_group_test.go
@@ -111,12 +111,8 @@ variable "cluster_cidr" {
   default = "172.31.0.0/16"
 }
 
-variable "vpc" {
-  default = "%s"
-}
-
-variable "subnet" {
-  default = "%s"
+data "tencentcloud_vpc_subnets" "vpc" {
+    availability_zone= var.availability_zone
 }
 
 variable "default_instance_type" {
@@ -124,7 +120,7 @@ variable "default_instance_type" {
 }
 
 resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
-  vpc_id                  = var.vpc
+  vpc_id                  = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
   cluster_cidr            = var.cluster_cidr
   cluster_max_pod_num     = 32
   cluster_name            = "tf-tke-unit-test"
@@ -140,7 +136,7 @@ resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
     internet_charge_type       = "TRAFFIC_POSTPAID_BY_HOUR"
     internet_max_bandwidth_out = 100
     public_ip_assigned         = true
-    subnet_id                  = var.subnet
+    subnet_id                  = data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
 
     data_disk {
       disk_type = "CLOUD_PREMIUM"
@@ -165,8 +161,8 @@ resource "tencentcloud_kubernetes_as_scaling_group" "as_test" {
     scaling_group_name   = "tf-tke-as-group-unit-test"
     max_size             = "5"
     min_size             = "0"
-    vpc_id               = var.vpc
-    subnet_ids           = [var.subnet]
+    vpc_id               = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
+    subnet_ids           = [data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id]
     project_id           = 0
     default_cooldown     = 400
     desired_capacity     = "0"
@@ -205,6 +201,6 @@ resource "tencentcloud_kubernetes_as_scaling_group" "as_test" {
   }
 }
 
-`, defaultVpcId, defaultSubnetId,
+`,
 	)
 }

--- a/tencentcloud/resource_tc_kubernetes_as_scaling_group_test.go
+++ b/tencentcloud/resource_tc_kubernetes_as_scaling_group_test.go
@@ -112,7 +112,8 @@ variable "cluster_cidr" {
 }
 
 data "tencentcloud_vpc_subnets" "vpc" {
-    availability_zone= var.availability_zone
+    is_default        = true
+    availability_zone = var.availability_zone
 }
 
 variable "default_instance_type" {

--- a/tencentcloud/resource_tc_kubernetes_cluster_test.go
+++ b/tencentcloud/resource_tc_kubernetes_cluster_test.go
@@ -144,7 +144,8 @@ func testAccTkeCluster(key, value string) string {
 	}
 
 	data "tencentcloud_vpc_subnets" "vpc" {
-       availability_zone=var.availability_zone
+      is_default        = true
+      availability_zone = var.availability_zone
     }
 
 	resource "tencentcloud_kubernetes_cluster" "managed_cluster" {

--- a/tencentcloud/resource_tc_kubernetes_cluster_test.go
+++ b/tencentcloud/resource_tc_kubernetes_cluster_test.go
@@ -30,7 +30,6 @@ func TestAccTencentCloudTkeResource(t *testing.T) {
 					resource.TestCheckResourceAttr(testTkeClusterResourceKey, "cluster_node_num", "1"),
 					resource.TestCheckResourceAttr(testTkeClusterResourceKey, "worker_instances_list.#", "1"),
 					resource.TestCheckResourceAttrSet(testTkeClusterResourceKey, "worker_instances_list.0.instance_id"),
-					resource.TestCheckResourceAttr(testTkeScaleWorkerResourceKey, "worker_instances_list.0.instance_charge_type", CVM_CHARGE_TYPE_POSTPAID),
 					resource.TestCheckResourceAttrSet(testTkeClusterResourceKey, "certification_authority"),
 					resource.TestCheckResourceAttrSet(testTkeClusterResourceKey, "user_name"),
 					resource.TestCheckResourceAttrSet(testTkeClusterResourceKey, "password"),
@@ -139,21 +138,17 @@ func testAccTkeCluster(key, value string) string {
 	variable "cluster_cidr" {
 	  default = "172.31.0.0/16"
 	}
-	
-	variable "vpc" {
-	  default = "%s"
-	}
-	
-	variable "subnet" {
-	  default = "%s"
-	}
-	
+
 	variable "default_instance_type" {
 	  default = "SA1.LARGE8"
 	}
-	
+
+	data "tencentcloud_vpc_subnets" "vpc" {
+       availability_zone=var.availability_zone
+    }
+
 	resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
-	  vpc_id                  = var.vpc
+	  vpc_id                  = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
 	  cluster_cidr            = var.cluster_cidr
 	  cluster_max_pod_num     = 32
 	  cluster_name            = "test"
@@ -169,7 +164,7 @@ func testAccTkeCluster(key, value string) string {
 	    internet_charge_type       = "TRAFFIC_POSTPAID_BY_HOUR"
 	    internet_max_bandwidth_out = 100
 	    public_ip_assigned         = true
-	    subnet_id                  = var.subnet
+	    subnet_id                  = data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
 	
 	    data_disk {
 	      disk_type = "CLOUD_PREMIUM"
@@ -188,6 +183,6 @@ func testAccTkeCluster(key, value string) string {
 	    "%s" = "%s"
 	  }
 	}
-`, defaultVpcId, defaultSubnetId, key, value,
+`, key, value,
 	)
 }

--- a/tencentcloud/resource_tc_kubernetes_scale_worker_test.go
+++ b/tencentcloud/resource_tc_kubernetes_scale_worker_test.go
@@ -142,7 +142,8 @@ variable "availability_zone" {
 }
 
 data "tencentcloud_vpc_subnets" "vpc" {
-    availability_zone= var.availability_zone
+    is_default        = true
+    availability_zone = var.availability_zone
 }
 
 variable "default_instance_type" {

--- a/tencentcloud/resource_tc_kubernetes_scale_worker_test.go
+++ b/tencentcloud/resource_tc_kubernetes_scale_worker_test.go
@@ -141,12 +141,8 @@ variable "availability_zone" {
   default = "ap-guangzhou-3"
 }
 
-variable "vpc" {
-  default = "` + defaultVpcId + `"
-}
-
-variable "subnet" {
-  default = "` + defaultSubnetId + `"
+data "tencentcloud_vpc_subnets" "vpc" {
+    availability_zone= var.availability_zone
 }
 
 variable "default_instance_type" {
@@ -157,7 +153,7 @@ variable "scale_instance_type" {
   default = "S2.LARGE16"
 }
 resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
-  vpc_id                  = var.vpc
+  vpc_id                  = data.tencentcloud_vpc_subnets.vpc.instance_list.0.vpc_id
   cluster_cidr            = "192.168.0.0/16"
   cluster_max_pod_num     = 32
   cluster_name            = "test"
@@ -173,7 +169,7 @@ resource "tencentcloud_kubernetes_cluster" "managed_cluster" {
     internet_charge_type       = "TRAFFIC_POSTPAID_BY_HOUR"
     internet_max_bandwidth_out = 100
     public_ip_assigned         = true
-    subnet_id                  = var.subnet
+    subnet_id                  = data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
 
     data_disk {
       disk_type = "CLOUD_PREMIUM"
@@ -199,7 +195,7 @@ resource tencentcloud_kubernetes_scale_worker test_scale {
 	instance_charge_type	   				= "PREPAID"
 	instance_charge_type_prepaid_period 	= 6
 	instance_charge_type_prepaid_renew_flag = "NOTIFY_AND_AUTO_RENEW"
-    subnet_id                  				= var.subnet
+    subnet_id                  				= data.tencentcloud_vpc_subnets.vpc.instance_list.0.subnet_id
     system_disk_type           				= "CLOUD_SSD"
     system_disk_size           				= 50
     internet_charge_type       				= "TRAFFIC_POSTPAID_BY_HOUR"

--- a/tencentcloud/service_tencentcloud_vpc.go
+++ b/tencentcloud/service_tencentcloud_vpc.go
@@ -149,7 +149,7 @@ func (me *VpcService) CreateVpc(ctx context.Context, name, cidr string,
 }
 
 func (me *VpcService) DescribeVpc(ctx context.Context, vpcId string) (info VpcBasicInfo, has int, errRet error) {
-	infos, err := me.DescribeVpcs(ctx, vpcId, "", nil)
+	infos, err := me.DescribeVpcs(ctx, vpcId, "", nil, nil)
 	if err != nil {
 		errRet = err
 		return
@@ -161,7 +161,7 @@ func (me *VpcService) DescribeVpc(ctx context.Context, vpcId string) (info VpcBa
 	return
 }
 
-func (me *VpcService) DescribeVpcs(ctx context.Context, vpcId, name string, tags map[string]string) (infos []VpcBasicInfo, errRet error) {
+func (me *VpcService) DescribeVpcs(ctx context.Context, vpcId, name string, tags map[string]string, isDefaultPtr *bool) (infos []VpcBasicInfo, errRet error) {
 	logId := getLogId(ctx)
 	request := vpc.NewDescribeVpcsRequest()
 	defer func() {
@@ -187,6 +187,10 @@ func (me *VpcService) DescribeVpcs(ctx context.Context, vpcId, name string, tags
 
 	if name != "" {
 		filters = me.fillFilter(filters, "vpc-name", name)
+	}
+
+	if isDefaultPtr != nil {
+		filters = me.fillFilter(filters, "is-default", map[bool]string{true: "true", false: "false"}[*isDefaultPtr])
 	}
 
 	for k, v := range tags {
@@ -258,7 +262,7 @@ getMoreData:
 
 }
 func (me *VpcService) DescribeSubnet(ctx context.Context, subnetId string) (info VpcSubnetBasicInfo, has int, errRet error) {
-	infos, err := me.DescribeSubnets(ctx, subnetId, "", "", "", nil)
+	infos, err := me.DescribeSubnets(ctx, subnetId, "", "", "", nil, nil)
 	if err != nil {
 		errRet = err
 		return
@@ -270,7 +274,7 @@ func (me *VpcService) DescribeSubnet(ctx context.Context, subnetId string) (info
 	return
 }
 
-func (me *VpcService) DescribeSubnets(ctx context.Context, subnetId, vpcId, subnetName, zone string, tags map[string]string) (infos []VpcSubnetBasicInfo, errRet error) {
+func (me *VpcService) DescribeSubnets(ctx context.Context, subnetId, vpcId, subnetName, zone string, tags map[string]string, isDefaultPtr *bool) (infos []VpcSubnetBasicInfo, errRet error) {
 
 	logId := getLogId(ctx)
 	request := vpc.NewDescribeSubnetsRequest()
@@ -300,6 +304,10 @@ func (me *VpcService) DescribeSubnets(ctx context.Context, subnetId, vpcId, subn
 	}
 	if zone != "" {
 		filters = me.fillFilter(filters, "zone", zone)
+	}
+
+	if isDefaultPtr != nil {
+		filters = me.fillFilter(filters, "is-default", map[bool]string{true: "true", false: "false"}[*isDefaultPtr])
 	}
 
 	for k, v := range tags {

--- a/website/docs/d/vpc_instances.html.markdown
+++ b/website/docs/d/vpc_instances.html.markdown
@@ -31,6 +31,7 @@ data "tencentcloud_vpc_instances" "name_instances" {
 
 The following arguments are supported:
 
+* `is_default` - (Optional) Filter default or no default vpcs.
 * `name` - (Optional) Name of the VPC to be queried.
 * `result_output_file` - (Optional) Used to save results.
 * `tags` - (Optional) Tags of the VPC to be queried.

--- a/website/docs/d/vpc_subnets.html.markdown
+++ b/website/docs/d/vpc_subnets.html.markdown
@@ -51,6 +51,8 @@ data "tencentcloud_vpc_subnets" "tags_instances" {
 
 The following arguments are supported:
 
+* `availability_zone` - (Optional) Zone of the subnet to be queried.
+* `is_default` - (Optional) Filter default or no default subnets.
 * `name` - (Optional) Name of the subnet to be queried.
 * `result_output_file` - (Optional) Used to save results.
 * `subnet_id` - (Optional) ID of the subnet to be queried.


### PR DESCRIPTION
 Data Source: `tencentcloud_vpc_instances` add new optional argument `is_default`.

 Data Source: `tencentcloud_vpc_subnets` add new output argument `availability_zone`,`is_default`.

```
variable "availability_zone" {
  default = "ap-guangzhou-3"
}

data "tencentcloud_vpc_subnets" "subnets" {
  is_default        = true
  availability_zone = var.availability_zone
}

output "default_subnet_id" {
  value = data.tencentcloud_vpc_subnets.subnets.instance_list.0.subnet_id
}

output "default_vpc_id" {
  value = data.tencentcloud_vpc_subnets.subnets.instance_list.0.vpc_id
}
```


