### PR TITLE
FIX BUG: Resource: `tencentcloud_vpn_gateway` of postpaid charge type cannot be deleted normally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ BUG FIXES:
 * Resource: `tencentcloud_clb_listener` argument `sni_switch` set error type.([#297](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/297)).
 * Resource: `tencentcloud_vpn_gateway` twice apply shows change argument `prepaid_renew_flag`.([#298](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/298)).
 * Resource: `tencentcloud_clb_instance` query status failed but applied in CLB resources.([#303](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/303)).
+* Resource: `tencentcloud_vpn_gateway` of postpaid charge type cannot be deleted normally.([#312](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/312)).
 * Resource: `tencentcloud_eni_attachment` fix detach may failed.
 * Data Source: `tencentcloud_security_group` set `project_id` error
 

--- a/tencentcloud/resource_tc_vpn_gateway.go
+++ b/tencentcloud/resource_tc_vpn_gateway.go
@@ -419,7 +419,7 @@ func resourceTencentCloudVpnGatewayDelete(d *schema.ResourceData, meta interface
 			if len(result.Response.VpnGatewaySet) == 0 {
 				return nil
 			}
-			if result.Response.VpnGatewaySet[0].ExpiredTime != nil {
+			if result.Response.VpnGatewaySet[0].ExpiredTime != nil && *result.Response.VpnGatewaySet[0].InstanceChargeType == VPN_CHARGE_TYPE_PREPAID {
 				expiredTime := *result.Response.VpnGatewaySet[0].ExpiredTime
 				if expiredTime != "0000-00-00 00:00:00" {
 					t, err := time.Parse("2006-01-02 15:04:05", expiredTime)


### PR DESCRIPTION
```
$ make testacc TESTARGS="-run=TestAccTencentCloudVpnGateway_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudVpnGateway_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-tencentcloud  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/gendoc   2.599s [no tests to run]
=== RUN   TestAccTencentCloudVpnGateway_basic
--- PASS: TestAccTencentCloudVpnGateway_basic (122.43s)
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud     127.529s

```