### PR TITLE
Fix VPN read nil issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,3 @@
-## 1.30.1 (Unreleased)
-
-BUG FIXES:
-
-* Resource: `tencentcloud_vpn_gateway` add `InternalError` SDK error to triggering the retry process.
-* Resource: `tencentcloud_vpn_gateway` fix read nil issue when the resource is not exist.
-* Resource: `tencentcloud_clb_listener_rule` fix unclear error message of SSL type error.
-* Resource: `tencentcloud_ha_vip_attachment` fix read nil issue when the resource is not exist.
 
 ## 1.30.0 (Unreleased)
 
@@ -34,6 +26,10 @@ BUG FIXES:
 * Resource: `tencentcloud_vpn_gateway` shows argument `prepaid_renew_flag` has changed when applied again([#298](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/298)).
 * Resource: `tencentcloud_clb_instance` fix the bug that instance id is not set in state file([#303](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/303)).
 * Resource: `tencentcloud_vpn_gateway` that is postpaid charge type cannot be deleted normally([#312](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/312)).
+* Resource: `tencentcloud_vpn_gateway` add `InternalError` SDK error to triggering the retry process.
+* Resource: `tencentcloud_vpn_gateway` fix read nil issue when the resource is not exist.
+* Resource: `tencentcloud_clb_listener_rule` fix unclear error message of SSL type error.
+* Resource: `tencentcloud_ha_vip_attachment` fix read nil issue when the resource is not exist.
 * Data Source: `tencentcloud_security_group` fix `project_id` type error.
 * Data Source: `tencentcloud_security_groups` fix `project_id` filter not works([#303](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/314)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 ## 1.30.0 (Unreleased)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.30.1 (Unreleased)
+
+BUG FIXES:
+
+* Resource: `tencentcloud_vpn_gateway` add `InternalError` SDK error to triggering the retry process.
+* Resource: `tencentcloud_vpn_gateway` fix read nil issue when the resource is not exist.
+* Resource: `tencentcloud_clb_listener_rule` fix unclear error message of SSL type error.
+* Resource: `tencentcloud_ha_vip_attachment` fix read nil issue when the resource is not exist.
+
 ## 1.30.0 (Unreleased)
 
 FEATURES:

--- a/tencentcloud/data_source_tc_vpn_gateways.go
+++ b/tencentcloud/data_source_tc_vpn_gateways.go
@@ -185,7 +185,7 @@ func dataSourceTencentCloudVpnGatewaysRead(d *schema.ResourceData, meta interfac
 		params["vpn-gateway-name"] = v.(string)
 	}
 	if v, ok := d.GetOk("public_ip_address"); ok {
-		params["ip-address"] = v.(string)
+		params["public-ip-address"] = v.(string)
 	}
 	if v, ok := d.GetOk("vpc_id"); ok {
 		params["vpc-id"] = v.(string)

--- a/tencentcloud/resource_tc_ha_vip.go
+++ b/tencentcloud/resource_tc_ha_vip.go
@@ -145,6 +145,7 @@ func resourceTencentCloudHaVipRead(d *schema.ResourceData, meta interface{}) err
 	haVipId := d.Id()
 	request := vpc.NewDescribeHaVipsRequest()
 	request.HaVipIds = []*string{&haVipId}
+
 	var response *vpc.DescribeHaVipsResponse
 	err := resource.Retry(readRetryTimeout, func() *resource.RetryError {
 		result, e := meta.(*TencentCloudClient).apiV3Conn.UseVpcClient().DescribeHaVips(request)

--- a/tencentcloud/resource_tc_ha_vip_eip_attachment.go
+++ b/tencentcloud/resource_tc_ha_vip_eip_attachment.go
@@ -87,14 +87,16 @@ func resourceTencentCloudHaVipEipAttachmentRead(d *schema.ResourceData, meta int
 
 	eip := ""
 	haVip := ""
+	has := false
 	vpcService := VpcService{
 		client: meta.(*TencentCloudClient).apiV3Conn,
 	}
 	err := resource.Retry(readRetryTimeout, func() *resource.RetryError {
-		eipId, haVipId, e := vpcService.DescribeHaVipEipById(ctx, haVipEipAttachmentId)
+		eipId, haVipId, flag, e := vpcService.DescribeHaVipEipById(ctx, haVipEipAttachmentId)
 		if e != nil {
 			return retryError(e)
 		}
+		has = flag
 		eip = eipId
 		haVip = haVipId
 		return nil
@@ -104,6 +106,9 @@ func resourceTencentCloudHaVipEipAttachmentRead(d *schema.ResourceData, meta int
 		return err
 	}
 
+	if !has {
+		d.SetId("")
+	}
 	_ = d.Set("havip_id", haVip)
 	_ = d.Set("address_ip", eip)
 	d.SetId(haVipEipAttachmentId)

--- a/tencentcloud/resource_tc_ha_vip_eip_attachment_test.go
+++ b/tencentcloud/resource_tc_ha_vip_eip_attachment_test.go
@@ -44,8 +44,8 @@ func testAccCheckHaVipEipAttachmentDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, _, err := vpcService.DescribeHaVipEipById(ctx, rs.Primary.ID)
-		if err == nil {
+		_, _, has, err := vpcService.DescribeHaVipEipById(ctx, rs.Primary.ID)
+		if err == nil && has {
 			return fmt.Errorf("HA VIP EIP attachment still exists: %s", rs.Primary.ID)
 		}
 	}
@@ -67,9 +67,12 @@ func testAccCheckHaVipEipAttachmentExists(n string) resource.TestCheckFunc {
 		vpcService := VpcService{
 			client: testAccProvider.Meta().(*TencentCloudClient).apiV3Conn,
 		}
-		_, _, err := vpcService.DescribeHaVipEipById(ctx, rs.Primary.ID)
+		_, _, has, err := vpcService.DescribeHaVipEipById(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
+		}
+		if !has {
+			return fmt.Errorf("HA VIP EIP attachment does not exist: %s", rs.Primary.ID)
 		}
 		return nil
 	}

--- a/tencentcloud/resource_tc_vpn_connection.go
+++ b/tencentcloud/resource_tc_vpn_connection.go
@@ -410,7 +410,7 @@ func resourceTencentCloudVpnConnectionCreate(d *schema.ResourceData, meta interf
 			if e != nil {
 				log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
 					logId, idRequest.GetAction(), idRequest.ToJsonString(), e.Error())
-				return retryError(e)
+				return retryError(e, "InternalError")
 			} else {
 				if len(result.Response.VpnConnectionSet) == 0 || *result.Response.VpnConnectionSet[0].VpnConnectionId == "" {
 					return resource.RetryableError(fmt.Errorf("Id is creating, wait..."))

--- a/tencentcloud/resource_tc_vpn_customer_gateway.go
+++ b/tencentcloud/resource_tc_vpn_customer_gateway.go
@@ -156,9 +156,19 @@ func resourceTencentCloudVpnCustomerGatewayRead(d *schema.ResourceData, meta int
 	err := resource.Retry(readRetryTimeout, func() *resource.RetryError {
 		result, e := meta.(*TencentCloudClient).apiV3Conn.UseVpcClient().DescribeCustomerGateways(request)
 		if e != nil {
-			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
-				logId, request.GetAction(), request.ToJsonString(), e.Error())
-			return retryError(e)
+			ee, ok := e.(*errors.TencentCloudSDKError)
+			if !ok {
+				return retryError(e)
+			}
+			if ee.Code == VPCNotFound {
+				log.Printf("[CRITAL]%s api[%s] success, request body [%s], reason[%s]\n",
+					logId, request.GetAction(), request.ToJsonString(), e.Error())
+				return nil
+			} else {
+				log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+					logId, request.GetAction(), request.ToJsonString(), e.Error())
+				return retryError(e)
+			}
 		}
 		response = result
 		return nil

--- a/tencentcloud/service_tencentcloud_ssl.go
+++ b/tencentcloud/service_tencentcloud_ssl.go
@@ -236,6 +236,9 @@ func (me *SslService) checkCertificateType(ctx context.Context, certId string, c
 	if certificate != nil && *certificate.CertType == checkType {
 		return true, nil
 	} else {
+		if certificate == nil {
+			return false, fmt.Errorf("Certificate Id %s is not found.", certId)
+		}
 		return false, nil
 	}
 

--- a/tencentcloud/service_tencentcloud_ssl.go
+++ b/tencentcloud/service_tencentcloud_ssl.go
@@ -237,7 +237,7 @@ func (me *SslService) checkCertificateType(ctx context.Context, certId string, c
 		return true, nil
 	} else {
 		if certificate == nil {
-			return false, fmt.Errorf("Certificate Id %s is not found.", certId)
+			return false, fmt.Errorf("certificate id %s is not found", certId)
 		}
 		return false, nil
 	}

--- a/tencentcloud/service_tencentcloud_vpc.go
+++ b/tencentcloud/service_tencentcloud_vpc.go
@@ -2426,6 +2426,7 @@ func (me *VpcService) DescribeHaVipEipById(ctx context.Context, haVipEipAttachme
 	items := strings.Split(haVipEipAttachmentId, "#")
 	if len(items) != 2 {
 		errRet = fmt.Errorf("decode HA VIP EIP attachment ID error %s", haVipEipAttachmentId)
+		return
 	}
 	haVipId := items[0]
 	addressIp := items[1]
@@ -2442,8 +2443,14 @@ func (me *VpcService) DescribeHaVipEipById(ctx context.Context, haVipEipAttachme
 				logId, request.GetAction(), request.ToJsonString(), err)
 			return retryError(err)
 		} else {
-			if len(result.Response.HaVipSet) != 1 {
-				return nil
+			length := len(result.Response.HaVipSet)
+			if length != 1 {
+				if length == 0 {
+					return nil
+				} else {
+					err = fmt.Errorf("query havip %s eip %s failed, the SDK returns %d HaVips", haVipId, addressIp, length)
+					return resource.NonRetryableError(err)
+				}
 			} else {
 				eip = *result.Response.HaVipSet[0].AddressIp
 				if addressIp != eip {

--- a/tencentcloud/validators.go
+++ b/tencentcloud/validators.go
@@ -65,9 +65,9 @@ func validateIp(v interface{}, k string) (ws []string, errors []error) {
 }
 
 // NOTE not exactly strict, but ok for now
-func validateIntegerInRange(min, max int) schema.SchemaValidateFunc {
+func validateIntegerInRange(min, max int64) schema.SchemaValidateFunc {
 	return func(v interface{}, k string) (ws []string, errors []error) {
-		value := v.(int)
+		value := int64(v.(int))
 		if value < min {
 			errors = append(errors, fmt.Errorf(
 				"%q cannot be lower than %d: %d", k, min, value))


### PR DESCRIPTION
* Resource: `tencentcloud_vpn_gateway` add `InternalError` SDK error to triggering the retry process.

* Resource: `tencentcloud_vpn_gateway` fix read nil issue when the resource is not exist.
* Resource: `tencentcloud_clb_listener_rule` fix unclear error message of SSL type error.
* Resource: `tencentcloud_ha_vip_attachment` fix read nil issue when the resource is not exist.