### PR TITLE
add time sleep to keep safe read

### DIFF
--- a/tencentcloud/resource_tc_cam_group_membership.go
+++ b/tencentcloud/resource_tc_cam_group_membership.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -95,7 +96,7 @@ func resourceTencentCloudCamGroupMembershipCreate(d *schema.ResourceData, meta i
 		log.Printf("[CRITAL]%s read CAM group membership failed, reason:%s\n", logId, err.Error())
 		return err
 	}
-
+	time.Sleep(3 * time.Second)
 	return resourceTencentCloudCamGroupMembershipRead(d, meta)
 }
 

--- a/tencentcloud/resource_tc_cam_group_policy_attachment.go
+++ b/tencentcloud/resource_tc_cam_group_policy_attachment.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -119,7 +120,7 @@ func resourceTencentCloudCamGroupPolicyAttachmentCreate(d *schema.ResourceData, 
 		log.Printf("[CRITAL]%s read CAM group policy failed, reason:%s\n", logId, err.Error())
 		return err
 	}
-
+	time.Sleep(3 * time.Second)
 	return resourceTencentCloudCamGroupPolicyAttachmentRead(d, meta)
 }
 

--- a/tencentcloud/resource_tc_cam_policy.go
+++ b/tencentcloud/resource_tc_cam_policy.go
@@ -44,6 +44,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -169,9 +170,12 @@ func resourceTencentCloudCamPolicyCreate(d *schema.ResourceData, meta interface{
 	policyId := d.Id()
 
 	err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
-		_, e := camService.DescribePolicyById(ctx, policyId)
+		instance, e := camService.DescribePolicyById(ctx, policyId)
 		if e != nil {
 			return retryError(e, "ResourceNotFound")
+		}
+		if instance == nil {
+			return resource.RetryableError(fmt.Errorf("creation not done"))
 		}
 		return nil
 	})
@@ -179,7 +183,7 @@ func resourceTencentCloudCamPolicyCreate(d *schema.ResourceData, meta interface{
 		log.Printf("[CRITAL]%s read CAM policy failed, reason:%s\n", logId, err.Error())
 		return err
 	}
-
+	time.Sleep(3 * time.Second)
 	return resourceTencentCloudCamPolicyRead(d, meta)
 }
 

--- a/tencentcloud/resource_tc_cam_role.go
+++ b/tencentcloud/resource_tc_cam_role.go
@@ -42,6 +42,7 @@ import (
 	"log"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -176,9 +177,12 @@ func resourceTencentCloudCamRoleCreate(d *schema.ResourceData, meta interface{})
 	roleId := d.Id()
 
 	err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
-		_, e := camService.DescribeRoleById(ctx, roleId)
+		instance, e := camService.DescribeRoleById(ctx, roleId)
 		if e != nil {
 			return retryError(e, "ResourceNotFound")
+		}
+		if instance == nil {
+			return resource.RetryableError(fmt.Errorf("creation not done"))
 		}
 		return nil
 	})
@@ -186,7 +190,7 @@ func resourceTencentCloudCamRoleCreate(d *schema.ResourceData, meta interface{})
 		log.Printf("[CRITAL]%s read CAM role failed, reason:%s\n", logId, err.Error())
 		return err
 	}
-
+	time.Sleep(3 * time.Second)
 	return resourceTencentCloudCamRoleRead(d, meta)
 }
 

--- a/tencentcloud/resource_tc_cam_role_policy_attachment.go
+++ b/tencentcloud/resource_tc_cam_role_policy_attachment.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -131,7 +132,7 @@ func resourceTencentCloudCamRolePolicyAttachmentCreate(d *schema.ResourceData, m
 		log.Printf("[CRITAL]%s read CAM role policy attachment failed, reason:%s\n", logId, err.Error())
 		return err
 	}
-
+	time.Sleep(3 * time.Second)
 	return resourceTencentCloudCamRolePolicyAttachmentRead(d, meta)
 }
 

--- a/tencentcloud/resource_tc_cam_saml_provider.go
+++ b/tencentcloud/resource_tc_cam_saml_provider.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -133,9 +134,12 @@ func resourceTencentCloudCamSAMLProviderCreate(d *schema.ResourceData, meta inte
 	}
 
 	err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
-		_, e := camService.DescribeSAMLProviderById(ctx, samlProviderId)
+		instance, e := camService.DescribeSAMLProviderById(ctx, samlProviderId)
 		if e != nil {
 			return retryError(e, "ResourceNotFound")
+		}
+		if instance == nil {
+			return resource.RetryableError(fmt.Errorf("creation not done"))
 		}
 		return nil
 	})
@@ -143,6 +147,7 @@ func resourceTencentCloudCamSAMLProviderCreate(d *schema.ResourceData, meta inte
 		log.Printf("[CRITAL]%s read CAM SAML provider failed, reason:%s\n", logId, err.Error())
 		return err
 	}
+	time.Sleep(3 * time.Second)
 
 	return resourceTencentCloudCamSAMLProviderRead(d, meta)
 }

--- a/tencentcloud/resource_tc_cam_user.go
+++ b/tencentcloud/resource_tc_cam_user.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -228,9 +229,12 @@ func resourceTencentCloudCamUserCreate(d *schema.ResourceData, meta interface{})
 		client: meta.(*TencentCloudClient).apiV3Conn,
 	}
 	err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
-		_, e := camService.DescribeUserById(ctx, userId)
+		instance, e := camService.DescribeUserById(ctx, userId)
 		if e != nil {
 			return retryError(e, "ResourceNotFound")
+		}
+		if instance == nil {
+			return resource.RetryableError(fmt.Errorf("creation not done"))
 		}
 		return nil
 	})
@@ -238,7 +242,7 @@ func resourceTencentCloudCamUserCreate(d *schema.ResourceData, meta interface{})
 		log.Printf("[CRITAL]%s read CAM user failed, reason:%s\n", logId, err.Error())
 		return err
 	}
-
+	time.Sleep(3 * time.Second)
 	return resourceTencentCloudCamUserRead(d, meta)
 }
 

--- a/tencentcloud/resource_tc_cam_user_policy_attachment.go
+++ b/tencentcloud/resource_tc_cam_user_policy_attachment.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -120,7 +121,7 @@ func resourceTencentCloudCamUserPolicyAttachmentCreate(d *schema.ResourceData, m
 		log.Printf("[CRITAL]%s read CAM user policy attachment failed, reason:%s\n", logId, err.Error())
 		return err
 	}
-
+	time.Sleep(3 * time.Second)
 	return resourceTencentCloudCamUserPolicyAttachmentRead(d, meta)
 }
 

--- a/tencentcloud/service_tencentcloud_cam.go
+++ b/tencentcloud/service_tencentcloud_cam.go
@@ -905,6 +905,7 @@ func (me *CamService) DescribeGroupById(ctx context.Context, groupId string) (ca
 	}
 	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
 		logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+	camInstance = response
 	return
 }
 


### PR DESCRIPTION
 make testacc TESTARGS="-run=TestAccTencentCloudCam"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudCam -timeout 120m
?       github.com/terraform-providers/terraform-provider-tencentcloud  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/gendoc  (cached) [no tests to run]
=== RUN   TestAccTencentCloudCamGroupMembershipsDataSource_basic
--- PASS: TestAccTencentCloudCamGroupMembershipsDataSource_basic (10.00s)
=== RUN   TestAccTencentCloudCamGroupPolicyAttachmentsDataSource_basic
--- PASS: TestAccTencentCloudCamGroupPolicyAttachmentsDataSource_basic (7.93s)
=== RUN   TestAccTencentCloudCamGroupsDataSource_basic
--- PASS: TestAccTencentCloudCamGroupsDataSource_basic (4.02s)
=== RUN   TestAccTencentCloudCamPoliciesDataSource_basic
--- PASS: TestAccTencentCloudCamPoliciesDataSource_basic (4.48s)
=== RUN   TestAccTencentCloudCamRolePolicyAttachmentsDataSource_basic
--- PASS: TestAccTencentCloudCamRolePolicyAttachmentsDataSource_basic (7.49s)
=== RUN   TestAccTencentCloudCamRolesDataSource_basic
--- PASS: TestAccTencentCloudCamRolesDataSource_basic (4.07s)
=== RUN   TestAccTencentCloudCamSAMLProvidersDataSource_basic
--- PASS: TestAccTencentCloudCamSAMLProvidersDataSource_basic (3.83s)
=== RUN   TestAccTencentCloudCamUserPolicyAttachmentsDataSource_basic
--- PASS: TestAccTencentCloudCamUserPolicyAttachmentsDataSource_basic (9.80s)
=== RUN   TestAccTencentCloudCamUsersDataSource_basic
--- PASS: TestAccTencentCloudCamUsersDataSource_basic (5.34s)
=== RUN   TestAccTencentCloudCamGroupMembership_basic
--- PASS: TestAccTencentCloudCamGroupMembership_basic (14.53s)
=== RUN   TestAccTencentCloudCamGroupPolicyAttachment_basic
--- PASS: TestAccTencentCloudCamGroupPolicyAttachment_basic (7.55s)
=== RUN   TestAccTencentCloudCamGroup_basic
--- PASS: TestAccTencentCloudCamGroup_basic (4.37s)
=== RUN   TestAccTencentCloudCamPolicy_basic
--- PASS: TestAccTencentCloudCamPolicy_basic (4.59s)
=== RUN   TestAccTencentCloudCamRolePolicyAttachment_basic
--- PASS: TestAccTencentCloudCamRolePolicyAttachment_basic (7.45s)
=== RUN   TestAccTencentCloudCamRole_basic
--- PASS: TestAccTencentCloudCamRole_basic (7.66s)
=== RUN   TestAccTencentCloudCamSAMLProvider_basic
--- PASS: TestAccTencentCloudCamSAMLProvider_basic (4.12s)
=== RUN   TestAccTencentCloudCamUserPolicyAttachment_basic
--- PASS: TestAccTencentCloudCamUserPolicyAttachment_basic (8.93s)
=== RUN   TestAccTencentCloudCamUser_basic
--- PASS: TestAccTencentCloudCamUser_basic (5.54s)
=== RUN   TestAccTencentCloudCamUser_nilPassword
--- PASS: TestAccTencentCloudCamUser_nilPassword (5.35s)
=== RUN   TestAccTencentCloudCamUser_withoutKey
--- PASS: TestAccTencentCloudCamUser_withoutKey (4.05s)
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud     132.118s
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/connectivity        [no test files]
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/internal/helper     [no test files]
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/ratelimit   [no test files]
