### PR TITLE
optimize error check logic

### DIFF
--- a/tencentcloud/resource_tc_cam_group.go
+++ b/tencentcloud/resource_tc_cam_group.go
@@ -114,13 +114,11 @@ func resourceTencentCloudCamGroupCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
-		instance, e := camService.DescribeGroupById(ctx, groupId)
+		_, e := camService.DescribeGroupById(ctx, groupId)
 		if e != nil {
 			return retryError(e, "ResourceNotFound")
 		}
-		if instance == nil || instance.Response == nil || instance.Response.GroupId == nil {
-			return resource.RetryableError(fmt.Errorf("creation not done"))
-		}
+
 		return nil
 	})
 	if err != nil {

--- a/tencentcloud/resource_tc_cam_group_policy_attachment.go
+++ b/tencentcloud/resource_tc_cam_group_policy_attachment.go
@@ -25,11 +25,13 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	cam "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116"
+	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
 )
 
 func resourceTencentCloudCamGroupPolicyAttachment() *schema.Resource {
@@ -139,6 +141,13 @@ func resourceTencentCloudCamGroupPolicyAttachmentRead(d *schema.ResourceData, me
 	err := resource.Retry(readRetryTimeout, func() *resource.RetryError {
 		result, e := camService.DescribeGroupPolicyAttachmentById(ctx, groupPolicyAttachmentId)
 		if e != nil {
+			if ee, ok := e.(*sdkErrors.TencentCloudSDKError); ok {
+				errCode := ee.GetCode()
+				//check if read empty
+				if strings.Contains(errCode, "ResourceNotFound") {
+					return nil
+				}
+			}
 			return retryError(e)
 		}
 		instance = result

--- a/tencentcloud/resource_tc_cam_policy.go
+++ b/tencentcloud/resource_tc_cam_policy.go
@@ -170,12 +170,9 @@ func resourceTencentCloudCamPolicyCreate(d *schema.ResourceData, meta interface{
 	policyId := d.Id()
 
 	err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
-		instance, e := camService.DescribePolicyById(ctx, policyId)
+		_, e := camService.DescribePolicyById(ctx, policyId)
 		if e != nil {
 			return retryError(e, "ResourceNotFound")
-		}
-		if instance == nil {
-			return resource.RetryableError(fmt.Errorf("creation not done"))
 		}
 		return nil
 	})

--- a/tencentcloud/resource_tc_cam_role.go
+++ b/tencentcloud/resource_tc_cam_role.go
@@ -181,6 +181,7 @@ func resourceTencentCloudCamRoleCreate(d *schema.ResourceData, meta interface{})
 		if e != nil {
 			return retryError(e, "ResourceNotFound")
 		}
+		//Describe Role is travel the list and match, get retry condition with this code
 		if instance == nil {
 			return resource.RetryableError(fmt.Errorf("creation not done"))
 		}

--- a/tencentcloud/resource_tc_cam_role_policy_attachment.go
+++ b/tencentcloud/resource_tc_cam_role_policy_attachment.go
@@ -25,11 +25,13 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	cam "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116"
+	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
 )
 
 func resourceTencentCloudCamRolePolicyAttachment() *schema.Resource {
@@ -123,6 +125,7 @@ func resourceTencentCloudCamRolePolicyAttachmentCreate(d *schema.ResourceData, m
 		if e != nil {
 			return retryError(e, "ResourceNotFound")
 		}
+
 		if instance == nil {
 			return resource.RetryableError(fmt.Errorf("creation not done"))
 		}
@@ -151,6 +154,13 @@ func resourceTencentCloudCamRolePolicyAttachmentRead(d *schema.ResourceData, met
 	err := resource.Retry(readRetryTimeout, func() *resource.RetryError {
 		result, e := camService.DescribeRolePolicyAttachmentById(ctx, rolePolicyAttachmentId)
 		if e != nil {
+			if ee, ok := e.(*sdkErrors.TencentCloudSDKError); ok {
+				errCode := ee.GetCode()
+				//check if read empty
+				if strings.Contains(errCode, "ResourceNotFound") || errCode == "InvalidParameter.RoleNotExist" {
+					return nil
+				}
+			}
 			return retryError(e)
 		}
 		instance = result

--- a/tencentcloud/resource_tc_cam_saml_provider.go
+++ b/tencentcloud/resource_tc_cam_saml_provider.go
@@ -134,12 +134,9 @@ func resourceTencentCloudCamSAMLProviderCreate(d *schema.ResourceData, meta inte
 	}
 
 	err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
-		instance, e := camService.DescribeSAMLProviderById(ctx, samlProviderId)
+		_, e := camService.DescribeSAMLProviderById(ctx, samlProviderId)
 		if e != nil {
 			return retryError(e, "ResourceNotFound")
-		}
-		if instance == nil {
-			return resource.RetryableError(fmt.Errorf("creation not done"))
 		}
 		return nil
 	})

--- a/tencentcloud/resource_tc_cam_user.go
+++ b/tencentcloud/resource_tc_cam_user.go
@@ -226,12 +226,9 @@ func resourceTencentCloudCamUserCreate(d *schema.ResourceData, meta interface{})
 		client: meta.(*TencentCloudClient).apiV3Conn,
 	}
 	err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
-		instance, e := camService.DescribeUserById(ctx, *response.Response.Name)
+		_, e := camService.DescribeUserById(ctx, *response.Response.Name)
 		if e != nil {
 			return retryError(e, "ResourceNotFound")
-		}
-		if instance == nil {
-			return resource.RetryableError(fmt.Errorf("creation not done"))
 		}
 		return nil
 	})

--- a/tencentcloud/resource_tc_cam_user_policy_attachment.go
+++ b/tencentcloud/resource_tc_cam_user_policy_attachment.go
@@ -25,11 +25,13 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	cam "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116"
+	sdkErrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
 )
 
 func resourceTencentCloudCamUserPolicyAttachment() *schema.Resource {
@@ -140,6 +142,13 @@ func resourceTencentCloudCamUserPolicyAttachmentRead(d *schema.ResourceData, met
 	err := resource.Retry(readRetryTimeout, func() *resource.RetryError {
 		result, e := camService.DescribeUserPolicyAttachmentById(ctx, userPolicyAttachmentId)
 		if e != nil {
+			if ee, ok := e.(*sdkErrors.TencentCloudSDKError); ok {
+				errCode := ee.GetCode()
+				//check if read empty
+				if strings.Contains(errCode, "ResourceNotFound") {
+					return nil
+				}
+			}
 			return retryError(e)
 		}
 		instance = result

--- a/tencentcloud/service_tencentcloud_cam.go
+++ b/tencentcloud/service_tencentcloud_cam.go
@@ -163,13 +163,6 @@ func (me *CamService) DescribeRolePolicyAttachmentById(ctx context.Context, role
 		if err != nil {
 			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
 				logId, request.GetAction(), request.ToJsonString(), err.Error())
-			if ee, ok := err.(*sdkErrors.TencentCloudSDKError); ok {
-				errCode := ee.GetCode()
-				//check if read empty
-				if strings.Contains(errCode, "ResourceNotFound") || errCode == "InvalidParameter.RoleNotExist" {
-					return
-				}
-			}
 			errRet = err
 			return
 		}
@@ -305,13 +298,6 @@ func (me *CamService) DescribeUserPolicyAttachmentById(ctx context.Context, user
 		if err != nil {
 			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
 				logId, request.GetAction(), request.ToJsonString(), err.Error())
-			if ee, ok := err.(*sdkErrors.TencentCloudSDKError); ok {
-				errCode := ee.GetCode()
-				//check if read empty
-				if strings.Contains(errCode, "ResourceNotFound") {
-					return
-				}
-			}
 			errRet = err
 			return
 		}
@@ -492,13 +478,6 @@ func (me *CamService) DescribeGroupPolicyAttachmentById(ctx context.Context, gro
 		if err != nil {
 			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
 				logId, request.GetAction(), request.ToJsonString(), err.Error())
-			if ee, ok := err.(*sdkErrors.TencentCloudSDKError); ok {
-				errCode := ee.GetCode()
-				//check if read empty
-				if strings.Contains(errCode, "ResourceNotFound") {
-					return
-				}
-			}
 			errRet = err
 			return
 		}
@@ -660,13 +639,6 @@ func (me *CamService) DescribePolicyById(ctx context.Context, policyId string) (
 
 	if err != nil {
 		log.Printf("[CRITAL]%s read CAM policy failed, reason:%s\n", logId, err.Error())
-		if ee, ok := err.(*sdkErrors.TencentCloudSDKError); ok {
-			errCode := ee.GetCode()
-			//check if read empty
-			if strings.Contains(errCode, "ResourceNotFound") {
-				return
-			}
-		}
 		return nil, err
 	} else {
 		if result == nil || result.Response == nil || result.Response.PolicyName == nil {
@@ -770,13 +742,6 @@ func (me *CamService) DescribeUserById(ctx context.Context, userId string) (resp
 	if err != nil {
 		log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
 			logId, request.GetAction(), request.ToJsonString(), err.Error())
-		if ee, ok := err.(*sdkErrors.TencentCloudSDKError); ok {
-			errCode := ee.GetCode()
-			//check if read empty
-			if strings.Contains(errCode, "ResourceNotFound") {
-				return
-			}
-		}
 		errRet = err
 		return
 	}
@@ -923,13 +888,6 @@ func (me *CamService) DescribeGroupsByFilter(ctx context.Context, params map[str
 		if err != nil {
 			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
 				logId, request.GetAction(), request.ToJsonString(), err.Error())
-			if ee, ok := err.(*sdkErrors.TencentCloudSDKError); ok {
-				errCode := ee.GetCode()
-				//check if read empty
-				if strings.Contains(errCode, "ResourceNotFound") {
-					return
-				}
-			}
 			errRet = err
 			return
 		}
@@ -985,13 +943,6 @@ func (me *CamService) DescribeGroupMembershipById(ctx context.Context, groupId s
 		response, err := me.client.UseCamClient().ListUsersForGroup(request)
 		if err != nil {
 			log.Printf("[CRITAL]%s read CAM group membership failed, reason:%s\n", logId, err.Error())
-			if ee, ok := err.(*sdkErrors.TencentCloudSDKError); ok {
-				errCode := ee.GetCode()
-				//check if read empty
-				if strings.Contains(errCode, "ResourceNotFound") {
-					return
-				}
-			}
 			errRet = err
 			return
 		}
@@ -1019,13 +970,6 @@ func (me *CamService) DescribeSAMLProviderById(ctx context.Context, providerName
 
 	if err != nil {
 		log.Printf("[CRITAL]%s read cam SAML provider failed, reason:%s\n", logId, err.Error())
-		if ee, ok := err.(*sdkErrors.TencentCloudSDKError); ok {
-			errCode := ee.GetCode()
-			//check if read empty
-			if strings.Contains(errCode, "ResourceNotFound") {
-				return
-			}
-		}
 		return nil, err
 	} else {
 		if result == nil || result.Response == nil || result.Response.Name == nil {


### PR DESCRIPTION
make testacc TESTARGS="-run=TestAccTencentCloudCam"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudCam -timeout 120m
?       github.com/terraform-providers/terraform-provider-tencentcloud  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/gendoc      (cached) [no tests to run]
=== RUN   TestAccTencentCloudCamGroupMembershipsDataSource_basic
--- PASS: TestAccTencentCloudCamGroupMembershipsDataSource_basic (10.77s)
=== RUN   TestAccTencentCloudCamGroupPolicyAttachmentsDataSource_basic
--- PASS: TestAccTencentCloudCamGroupPolicyAttachmentsDataSource_basic (7.70s)
=== RUN   TestAccTencentCloudCamGroupsDataSource_basic
--- PASS: TestAccTencentCloudCamGroupsDataSource_basic (4.20s)
=== RUN   TestAccTencentCloudCamPoliciesDataSource_basic
--- PASS: TestAccTencentCloudCamPoliciesDataSource_basic (4.74s)
=== RUN   TestAccTencentCloudCamRolePolicyAttachmentsDataSource_basic
--- PASS: TestAccTencentCloudCamRolePolicyAttachmentsDataSource_basic (7.54s)
=== RUN   TestAccTencentCloudCamRolesDataSource_basic
--- PASS: TestAccTencentCloudCamRolesDataSource_basic (3.97s)
=== RUN   TestAccTencentCloudCamSAMLProvidersDataSource_basic
--- PASS: TestAccTencentCloudCamSAMLProvidersDataSource_basic (3.72s)
=== RUN   TestAccTencentCloudCamUserPolicyAttachmentsDataSource_basic
--- PASS: TestAccTencentCloudCamUserPolicyAttachmentsDataSource_basic (9.42s)
=== RUN   TestAccTencentCloudCamUsersDataSource_basic
--- PASS: TestAccTencentCloudCamUsersDataSource_basic (5.59s)
=== RUN   TestAccTencentCloudCamGroupMembership_basic
--- PASS: TestAccTencentCloudCamGroupMembership_basic (16.50s)
=== RUN   TestAccTencentCloudCamGroupPolicyAttachment_basic
--- PASS: TestAccTencentCloudCamGroupPolicyAttachment_basic (7.49s)
=== RUN   TestAccTencentCloudCamGroup_basic
--- PASS: TestAccTencentCloudCamGroup_basic (4.28s)
=== RUN   TestAccTencentCloudCamPolicy_basic
--- PASS: TestAccTencentCloudCamPolicy_basic (4.68s)
=== RUN   TestAccTencentCloudCamRolePolicyAttachment_basic
--- PASS: TestAccTencentCloudCamRolePolicyAttachment_basic (7.45s)
=== RUN   TestAccTencentCloudCamRole_basic
--- PASS: TestAccTencentCloudCamRole_basic (7.40s)
=== RUN   TestAccTencentCloudCamSAMLProvider_basic
--- PASS: TestAccTencentCloudCamSAMLProvider_basic (4.09s)
=== RUN   TestAccTencentCloudCamUserPolicyAttachment_basic
--- PASS: TestAccTencentCloudCamUserPolicyAttachment_basic (9.04s)
=== RUN   TestAccTencentCloudCamUser_basic
--- PASS: TestAccTencentCloudCamUser_basic (5.56s)
=== RUN   TestAccTencentCloudCamUser_nilPassword
--- PASS: TestAccTencentCloudCamUser_nilPassword (5.02s)
=== RUN   TestAccTencentCloudCamUser_withoutKey
--- PASS: TestAccTencentCloudCamUser_withoutKey (4.08s)
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud        133.923s
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/connectivity   [no test files]
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/internal/helper        [no test files]
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/ratelimit      [no test files]
