### PR TITLE
bug fix : `tencentcloud_kubernetes_as_scaling_group` set a value to argument `key_ids` cause error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 1.31.0 (Unreleased)
+
+
+BUG FIXES: 
+
+* Resource: `tencentcloud_kubernetes_as_scaling_group` set a value to argument `key_ids` cause error .
+
 ## 1.30.6 (March 30, 2020)
 
 ENHANCEMENTS:

--- a/tencentcloud/resource_tc_kubernetes_as_scaling_group.go
+++ b/tencentcloud/resource_tc_kubernetes_as_scaling_group.go
@@ -583,6 +583,10 @@ func kubernetesAsScalingConfigParaSerial(dMap map[string]interface{}, meta inter
 		}
 	}
 
+	if request.LoginSettings.Password != nil && *request.LoginSettings.Password == "" {
+		request.LoginSettings.Password = nil
+	}
+
 	if request.LoginSettings.Password == nil && len(request.LoginSettings.KeyIds) == 0 {
 		errRet = fmt.Errorf("Parameters `key_ids` and `password` should be set one")
 		return result, errRet


### PR DESCRIPTION


bug fix : `tencentcloud_kubernetes_as_scaling_group` set a value to argument `key_ids` cause error