### PR TITLE
fix multi-attachment deletion issue

### DIFF
--- a/tencentcloud/resource_tc_clb_attachment.go
+++ b/tencentcloud/resource_tc_clb_attachment.go
@@ -282,9 +282,7 @@ func resourceTencentCloudClbServerAttachementAdd(d *schema.ResourceData, meta in
 	for _, inst_ := range add {
 		inst := inst_.(map[string]interface{})
 		request.Targets = append(request.Targets, clbNewTarget(inst["instance_id"], inst["port"], inst["weight"]))
-
 	}
-
 	err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
 		requestId := ""
 		response, e := meta.(*TencentCloudClient).apiV3Conn.UseClbClient().RegisterTargets(request)
@@ -306,7 +304,6 @@ func resourceTencentCloudClbServerAttachementAdd(d *schema.ResourceData, meta in
 		return err
 	}
 	return nil
-
 }
 
 func resourceTencentCloudClbServerAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -321,7 +318,6 @@ func resourceTencentCloudClbServerAttachmentUpdate(d *schema.ResourceData, meta 
 		ns := n.(*schema.Set)
 		add := ns.Difference(os).List()
 		remove := os.Difference(ns).List()
-
 		if len(remove) > 0 {
 			err := resourceTencentCloudClbServerAttachementRemove(d, meta, remove)
 			if err != nil {

--- a/tencentcloud/resource_tc_clb_attachment.go
+++ b/tencentcloud/resource_tc_clb_attachment.go
@@ -177,16 +177,16 @@ func resourceTencentCloudClbServerAttachmentDelete(d *schema.ResourceData, meta 
 	listenerId := items[1]
 	clbId := items[2]
 
-	//check exists
-	clbService := ClbService{
-		client: meta.(*TencentCloudClient).apiV3Conn,
-	}
-
 	request := clb.NewDeregisterTargetsRequest()
 	request.ListenerId = &listenerId
 	request.LoadBalancerId = helper.String(clbId)
 	if locationId != "" {
 		request.LocationId = helper.String(locationId)
+	}
+
+	//check exists
+	clbService := ClbService{
+		client: meta.(*TencentCloudClient).apiV3Conn,
 	}
 
 	err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
@@ -201,7 +201,6 @@ func resourceTencentCloudClbServerAttachmentDelete(d *schema.ResourceData, meta 
 		log.Printf("[CRITAL]%s reason[%+v]", logId, err)
 		return err
 	}
-
 	return nil
 }
 
@@ -209,7 +208,6 @@ func resourceTencentCloudClbServerAttachementRemove(d *schema.ResourceData, meta
 	defer logElapsed("resource.tencentcloud_clb_attachment.remove")()
 
 	logId := getLogId(contextNil)
-
 	attachmentId := d.Id()
 	items := strings.Split(attachmentId, "#")
 	if len(items) < 3 {
@@ -229,39 +227,36 @@ func resourceTencentCloudClbServerAttachementRemove(d *schema.ResourceData, meta
 	for _, inst_ := range remove {
 		inst := inst_.(map[string]interface{})
 		request.Targets = append(request.Targets, clbNewTarget(inst["instance_id"], inst["port"], inst["weight"]))
-
 	}
 
-	if len(request.Targets) > 0 {
-		err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
-			requestId := ""
-			response, e := meta.(*TencentCloudClient).apiV3Conn.UseClbClient().DeregisterTargets(request)
-			if e != nil {
-				ee, ok := e.(*sdkErrors.TencentCloudSDKError)
-				if !ok {
-					return retryError(ee)
-				}
-				if ee.Code == "InvalidParameter" {
-					return nil
-				} else {
-					return retryError(e)
-				}
-
-			} else {
-				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
-					logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
-				requestId = *response.Response.RequestId
-				retryErr := waitForTaskFinish(requestId, meta.(*TencentCloudClient).apiV3Conn.UseClbClient())
-				if retryErr != nil {
-					return resource.NonRetryableError(errors.WithStack(retryErr))
-				}
+	err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+		requestId := ""
+		response, e := meta.(*TencentCloudClient).apiV3Conn.UseClbClient().DeregisterTargets(request)
+		if e != nil {
+			ee, ok := e.(*sdkErrors.TencentCloudSDKError)
+			if !ok {
+				return retryError(ee)
 			}
-			return nil
-		})
-		if err != nil {
-			log.Printf("[CRITAL]%s remove CLB attachment failed, reason:%+v", logId, err)
-			return err
+			if ee.Code == "InvalidParameter" {
+				return nil
+			} else {
+				return retryError(e)
+			}
+
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+			requestId = *response.Response.RequestId
+			retryErr := waitForTaskFinish(requestId, meta.(*TencentCloudClient).apiV3Conn.UseClbClient())
+			if retryErr != nil {
+				return resource.NonRetryableError(errors.WithStack(retryErr))
+			}
 		}
+		return nil
+	})
+	if err != nil {
+		log.Printf("[CRITAL]%s remove CLB attachment failed, reason:%+v", logId, err)
+		return err
 	}
 	return nil
 }
@@ -290,27 +285,25 @@ func resourceTencentCloudClbServerAttachementAdd(d *schema.ResourceData, meta in
 
 	}
 
-	if len(request.Targets) > 0 {
-		err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
-			requestId := ""
-			response, e := meta.(*TencentCloudClient).apiV3Conn.UseClbClient().RegisterTargets(request)
-			if e != nil {
-				return retryError(e)
-			} else {
-				log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
-					logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
-				requestId = *response.Response.RequestId
-				retryErr := waitForTaskFinish(requestId, meta.(*TencentCloudClient).apiV3Conn.UseClbClient())
-				if retryErr != nil {
-					return resource.NonRetryableError(errors.WithStack(retryErr))
-				}
+	err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+		requestId := ""
+		response, e := meta.(*TencentCloudClient).apiV3Conn.UseClbClient().RegisterTargets(request)
+		if e != nil {
+			return retryError(e)
+		} else {
+			log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+			requestId = *response.Response.RequestId
+			retryErr := waitForTaskFinish(requestId, meta.(*TencentCloudClient).apiV3Conn.UseClbClient())
+			if retryErr != nil {
+				return resource.NonRetryableError(errors.WithStack(retryErr))
 			}
-			return nil
-		})
-		if err != nil {
-			log.Printf("[CRITAL]%s add CLB attachment failed, reason:%+v", logId, err)
-			return err
 		}
+		return nil
+	})
+	if err != nil {
+		log.Printf("[CRITAL]%s add CLB attachment failed, reason:%+v", logId, err)
+		return err
 	}
 	return nil
 

--- a/tencentcloud/service_tencentcloud_clb.go
+++ b/tencentcloud/service_tencentcloud_clb.go
@@ -506,6 +506,13 @@ func (me *ClbService) DeleteAttachmentById(ctx context.Context, clbId string, li
 	ratelimit.Check(request.GetAction())
 	response, err := me.client.UseClbClient().DeregisterTargets(request)
 	if err != nil {
+		ee, ok := err.(*sdkErrors.TencentCloudSDKError)
+		if !ok {
+			return errors.WithStack(ee)
+		}
+		if ee.GetCode() == "InvalidParameter" {
+			return nil
+		}
 		return errors.WithStack(err)
 	}
 	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",

--- a/tencentcloud/service_tencentcloud_clb.go
+++ b/tencentcloud/service_tencentcloud_clb.go
@@ -507,10 +507,7 @@ func (me *ClbService) DeleteAttachmentById(ctx context.Context, clbId string, li
 	response, err := me.client.UseClbClient().DeregisterTargets(request)
 	if err != nil {
 		ee, ok := err.(*sdkErrors.TencentCloudSDKError)
-		if !ok {
-			return errors.WithStack(ee)
-		}
-		if ee.GetCode() == "InvalidParameter" {
+		if ok && ee.GetCode() == "InvalidParameter" {
 			return nil
 		}
 		return errors.WithStack(err)


### PR DESCRIPTION
create:

`data.tencentcloud_instances.default: Refreshing state...
tencentcloud_clb_attachment.default[0]: Refreshing state... [id=#lbl-g84n3gr2#lb-1sp4y4so]
tencentcloud_clb_attachment.default[1]: Refreshing state... [id=#lbl-g84n3gr2#lb-1sp4y4so]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # tencentcloud_clb_attachment.default[0] will be created
  + resource "tencentcloud_clb_attachment" "default" {
      + clb_id        = "lb-1sp4y4so"
      + id            = (known after apply)
      + listener_id   = "lbl-g84n3gr2"
      + protocol_type = (known after apply)

      + targets {
          + instance_id = "ins-fa2damgc"
          + port        = 80
          + weight      = 10
        }
    }

  # tencentcloud_clb_attachment.default[1] will be created
  + resource "tencentcloud_clb_attachment" "default" {
      + clb_id        = "lb-1sp4y4so"
      + id            = (known after apply)
      + listener_id   = "lbl-g84n3gr2"
      + protocol_type = (known after apply)

      + targets {
          + instance_id = "ins-bvpf6j4w"
          + port        = 80
          + weight      = 10
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.


Warning: Quoted type constraints are deprecated

  on variable.tf line 3, in variable "instance_ip":
   3:   type = "list"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "list" and write
list(string) instead to explicitly indicate that the list elements are
strings.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_clb_attachment.default[0]: Creating...
tencentcloud_clb_attachment.default[1]: Creating...
tencentcloud_clb_attachment.default[0]: Creation complete after 3s [id=#lbl-g84n3gr2#lb-1sp4y4so]
tencentcloud_clb_attachment.default[1]: Creation complete after 8s [id=#lbl-g84n3gr2#lb-1sp4y4so]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
`