### PR TITLE
fix bugs when trying destroy multi-attachments resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 BUG FIXES: 
 
 * Resource: `tencentcloud_keypair` fix bug when trying to destroy resources containing CVM and key pair([#375](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/375)).
+* Resource: `tencentcloud_clb_attachment` fix bug when trying to destroy multiple attachments in the array. 
+* Resource: `tencentcloud_cam_group_membership` fix bug when trying to destroy multiple users in the array. 
+
 
 ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ BUG FIXES:
 * Resource: `tencentcloud_clb_attachment` fix bug when trying to destroy multiple attachments in the array. 
 * Resource: `tencentcloud_cam_group_membership` fix bug when trying to destroy multiple users in the array. 
 
-
 ENHANCEMENTS:
 
 * Resource: `tencentcloud_mysql_account` add new argument `host`([#372](https://github.com/terraform-providers/terraform-provider-tencentcloud/issues/372)).

--- a/tencentcloud/resource_tc_cam_group_membership.go
+++ b/tencentcloud/resource_tc_cam_group_membership.go
@@ -146,7 +146,6 @@ func resourceTencentCloudCamGroupMembershipRead(d *schema.ResourceData, meta int
 		}
 		_ = d.Set("user_ids", exactMembers)
 	} else {
-		log.Printf("!!! test import")
 		_ = d.Set("user_ids", members)
 	}
 	_ = d.Set("group_id", groupId)

--- a/tencentcloud/resource_tc_cam_group_membership.go
+++ b/tencentcloud/resource_tc_cam_group_membership.go
@@ -132,7 +132,6 @@ func resourceTencentCloudCamGroupMembershipRead(d *schema.ResourceData, meta int
 	//in this situation, import action is not supported
 	stateMembers := d.Get("user_ids").(*schema.Set).List()
 	if len(stateMembers) != 0 {
-		log.Printf("the length of state members %d", len(stateMembers))
 		//the old state exist
 		//create a new membership with state
 		exactMembers := make([]*string, 0)

--- a/tencentcloud/resource_tc_cam_group_membership.go
+++ b/tencentcloud/resource_tc_cam_group_membership.go
@@ -130,17 +130,14 @@ func resourceTencentCloudCamGroupMembershipRead(d *schema.ResourceData, meta int
 	//this may cause problems when there are members in two dimensions array
 	//need to read state of the tfstate file to clear the relationships
 	//in this situation, import action is not supported
-	stateMembers := d.Get("user_ids").(*schema.Set).List()
-	if len(stateMembers) != 0 {
+	stateMembers := d.Get("user_ids").(*schema.Set)
+	if stateMembers.Len() != 0 {
 		//the old state exist
 		//create a new membership with state
 		exactMembers := make([]*string, 0)
-		for _, sv := range stateMembers {
-			svv := sv.(string)
-			for _, v := range members {
-				if svv == *v {
-					exactMembers = append(exactMembers, v)
-				}
+		for _, v := range members {
+			if stateMembers.Contains(*v) {
+				exactMembers = append(exactMembers, v)
 			}
 		}
 		_ = d.Set("user_ids", exactMembers)

--- a/tencentcloud/resource_tc_cam_group_membership.go
+++ b/tencentcloud/resource_tc_cam_group_membership.go
@@ -127,9 +127,29 @@ func resourceTencentCloudCamGroupMembershipRead(d *schema.ResourceData, meta int
 		d.SetId("")
 		return nil
 	}
-
+	//this may cause problems when there are members in two dimensions array
+	//need to read state of the tfstate file to clear the relationships
+	//in this situation, import action is not supported
+	stateMembers := d.Get("user_ids").(*schema.Set).List()
+	if len(stateMembers) != 0 {
+		log.Printf("the length of state members %d", len(stateMembers))
+		//the old state exist
+		//create a new membership with state
+		exactMembers := make([]*string, 0)
+		for _, sv := range stateMembers {
+			svv := sv.(string)
+			for _, v := range members {
+				if svv == *v {
+					exactMembers = append(exactMembers, v)
+				}
+			}
+		}
+		_ = d.Set("user_ids", exactMembers)
+	} else {
+		log.Printf("!!! test import")
+		_ = d.Set("user_ids", members)
+	}
 	_ = d.Set("group_id", groupId)
-	_ = d.Set("user_ids", members)
 
 	return nil
 }

--- a/tencentcloud/resource_tc_clb_attachment.go
+++ b/tencentcloud/resource_tc_clb_attachment.go
@@ -374,17 +374,18 @@ func resourceTencentCloudClbServerAttachmentRead(d *schema.ResourceData, meta in
 	//this may cause problems when there are members in two dimensions array
 	//need to read state of the tfstate file to clear the relationships
 	//in this situation, import action is not supported
-	stateTargets := d.Get("targets").(*schema.Set).List()
-	if len(stateTargets) != 0 {
+	stateTargets := d.Get("targets").(*schema.Set)
+	if stateTargets.Len() != 0 {
 		//the old state exist
 		//create a new attachment with state
 		exactTargets := make([]*clb.Backend, 0)
-		for _, sv := range stateTargets {
-			svv := sv.(map[string]interface{})
-			for _, v := range onlineTargets {
-				if int(*v.Weight) == svv["weight"] && int(*v.Port) == svv["port"] && *v.InstanceId == svv["instance_id"] {
-					exactTargets = append(exactTargets, v)
-				}
+		for _, v := range onlineTargets {
+			if stateTargets.Contains(map[string]interface{}{
+				"weight":      int(*v.Weight),
+				"port":        int(*v.Port),
+				"instance_id": *v.InstanceId,
+			}) {
+				exactTargets = append(exactTargets, v)
 			}
 		}
 		_ = d.Set("targets", flattenBackendList(exactTargets))

--- a/tencentcloud/resource_tc_clb_attachment.go
+++ b/tencentcloud/resource_tc_clb_attachment.go
@@ -357,17 +357,39 @@ func resourceTencentCloudClbServerAttachmentRead(d *schema.ResourceData, meta in
 	_ = d.Set("listener_id", listenerId)
 	_ = d.Set("protocol_type", instance.Protocol)
 
+	var onlineTargets []*clb.Backend
 	if *instance.Protocol == CLB_LISTENER_PROTOCOL_HTTP || *instance.Protocol == CLB_LISTENER_PROTOCOL_HTTPS {
 		_ = d.Set("rule_id", locationId)
 		if len(instance.Rules) > 0 {
 			for _, loc := range instance.Rules {
 				if locationId == "" || locationId == *loc.LocationId {
-					_ = d.Set("targets", flattenBackendList(loc.Targets))
+					onlineTargets = loc.Targets
 				}
 			}
 		}
 	} else if *instance.Protocol == CLB_LISTENER_PROTOCOL_TCP || *instance.Protocol == CLB_LISTENER_PROTOCOL_UDP {
-		_ = d.Set("targets", flattenBackendList(instance.Targets))
+		onlineTargets = instance.Targets
+	}
+
+	//this may cause problems when there are members in two dimensions array
+	//need to read state of the tfstate file to clear the relationships
+	//in this situation, import action is not supported
+	stateTargets := d.Get("targets").(*schema.Set).List()
+	if len(stateTargets) != 0 {
+		//the old state exist
+		//create a new attachment with state
+		exactTargets := make([]*clb.Backend, 0)
+		for _, sv := range stateTargets {
+			svv := sv.(map[string]interface{})
+			for _, v := range onlineTargets {
+				if int(*v.Weight) == svv["weight"] && int(*v.Port) == svv["port"] && *v.InstanceId == svv["instance_id"] {
+					exactTargets = append(exactTargets, v)
+				}
+			}
+		}
+		_ = d.Set("targets", flattenBackendList(exactTargets))
+	} else {
+		_ = d.Set("targets", flattenBackendList(onlineTargets))
 	}
 
 	return nil

--- a/tencentcloud/resource_tc_redis_instance.go
+++ b/tencentcloud/resource_tc_redis_instance.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
@@ -44,6 +45,7 @@ func resourceTencentCloudRedisInstance() *schema.Resource {
 	for _, v := range REDIS_NAMES {
 		types = append(types, "`"+v+"`")
 	}
+	sort.Strings(types)
 	typeStr := strings.Trim(strings.Join(types, ","), ",")
 
 	return &schema.Resource{

--- a/tencentcloud/service_tencentcloud_cam.go
+++ b/tencentcloud/service_tencentcloud_cam.go
@@ -899,7 +899,13 @@ func (me *CamService) DescribeGroupById(ctx context.Context, groupId string) (ca
 	if err != nil {
 		log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
 			logId, request.GetAction(), request.ToJsonString(), err.Error())
-
+		if ee, ok := err.(*sdkErrors.TencentCloudSDKError); ok {
+			errCode := ee.GetCode()
+			//check if read empty
+			if strings.Contains(errCode, "ResourceNotFound") {
+				return
+			}
+		}
 		errRet = err
 		return
 	}

--- a/website/docs/r/redis_instance.html.markdown
+++ b/website/docs/r/redis_instance.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `security_groups` - (Optional, ForceNew) ID of security group. If both vpc_id and subnet_id are not set, this argument should not be set either.
 * `subnet_id` - (Optional, ForceNew) Specifies which subnet the instance should belong to.
 * `tags` - (Optional) Instance tags.
-* `type` - (Optional, ForceNew) Instance type. Available values: `cluster_redis`,`cluster_ckv`,`standalone_redis`,`master_slave_redis5.0`,`cluster_redis5.0`,`master_slave_redis`,`master_slave_ckv`, specific region support specific types, need to refer data `tencentcloud_redis_zone_config`.
+* `type` - (Optional, ForceNew) Instance type. Available values: `cluster_ckv`,`cluster_redis5.0`,`cluster_redis`,`master_slave_ckv`,`master_slave_redis5.0`,`master_slave_redis`,`standalone_redis`, specific region support specific types, need to refer data `tencentcloud_redis_zone_config`.
 * `vpc_id` - (Optional, ForceNew) ID of the vpc with which the instance is to be associated.
 
 ## Attributes Reference


### PR DESCRIPTION
apply

```
$ terraform apply
2020/04/13 12:24:40 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----
data.tencentcloud_instances.default: Refreshing state...

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # tencentcloud_cam_group.group_basic will be created
  + resource "tencentcloud_cam_group" "group_basic" {
      + create_time = (known after apply)
      + id          = (known after apply)
      + name        = "cam-group-membership-test"
      + remark      = "test"
    }

  # tencentcloud_cam_group_membership.group_membership_basic[0] will be created
  + resource "tencentcloud_cam_group_membership" "group_membership_basic" {
      + group_id = (known after apply)
      + id       = (known after apply)
      + user_ids = (known after apply)
    }

  # tencentcloud_cam_group_membership.group_membership_basic[1] will be created
  + resource "tencentcloud_cam_group_membership" "group_membership_basic" {
      + group_id = (known after apply)
      + id       = (known after apply)
      + user_ids = (known after apply)
    }

  # tencentcloud_cam_user.foo will be created
  + resource "tencentcloud_cam_user" "foo" {
      + console_login       = true
      + country_code        = "86"
      + email               = "1234@qq.com"
      + force_delete        = true
      + id                  = (known after apply)
      + name                = "cam-user-test22"
      + need_reset_password = true
      + password            = (sensitive value)
      + phone_num           = "12345678910"
      + remark              = "test"
      + secret_id           = (sensitive value)
      + secret_key          = (sensitive value)
      + uid                 = (known after apply)
      + uin                 = (known after apply)
      + use_api             = true
    }

  # tencentcloud_cam_user.user_basic will be created
  + resource "tencentcloud_cam_user" "user_basic" {
      + console_login       = true
      + country_code        = "86"
      + email               = "1234@qq.com"
      + force_delete        = true
      + id                  = (known after apply)
      + name                = "cam-user-test33"
      + need_reset_password = true
      + password            = (sensitive value)
      + phone_num           = "12345678910"
      + remark              = "test"
      + secret_id           = (sensitive value)
      + secret_key          = (sensitive value)
      + uid                 = (known after apply)
      + uin                 = (known after apply)
      + use_api             = true
    }

  # tencentcloud_clb_attachment.default[0] will be created
  + resource "tencentcloud_clb_attachment" "default" {
      + clb_id        = "lb-1sp4y4so"
      + id            = (known after apply)
      + listener_id   = "lbl-g84n3gr2"
      + protocol_type = (known after apply)

      + targets {
          + instance_id = "ins-bvpf6j4w"
          + port        = 80
          + weight      = 10
        }
    }

  # tencentcloud_clb_attachment.default[1] will be created
  + resource "tencentcloud_clb_attachment" "default" {
      + clb_id        = "lb-1sp4y4so"
      + id            = (known after apply)
      + listener_id   = "lbl-g84n3gr2"
      + protocol_type = (known after apply)

      + targets {
          + instance_id = "ins-fa2damgc"
          + port        = 80
          + weight      = 10
        }
    }

Plan: 7 to add, 0 to change, 0 to destroy.


Warning: Quoted type constraints are deprecated

  on variable.tf line 3, in variable "instance_ip":
   3:   type = "list"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "list" and write
list(string) instead to explicitly indicate that the list elements are
strings.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tencentcloud_cam_user.user_basic: Creating...
tencentcloud_cam_group.group_basic: Creating...
tencentcloud_clb_attachment.default[1]: Creating...
tencentcloud_clb_attachment.default[0]: Creating...
tencentcloud_cam_user.foo: Creating...
tencentcloud_clb_attachment.default[1]: Creation complete after 3s [id=#lbl-g84n3gr2#lb-1sp4y4so]
tencentcloud_clb_attachment.default[0]: Creation complete after 7s [id=#lbl-g84n3gr2#lb-1sp4y4so]
tencentcloud_cam_user.user_basic: Still creating... [10s elapsed]
tencentcloud_cam_user.foo: Still creating... [10s elapsed]
tencentcloud_cam_group.group_basic: Still creating... [10s elapsed]
tencentcloud_cam_group.group_basic: Creation complete after 10s [id=122792]
tencentcloud_cam_user.foo: Creation complete after 11s [id=cam-user-test22]
tencentcloud_cam_user.user_basic: Creation complete after 11s [id=cam-user-test33]
tencentcloud_cam_group_membership.group_membership_basic[0]: Creating...
tencentcloud_cam_group_membership.group_membership_basic[1]: Creating...
tencentcloud_cam_group_membership.group_membership_basic[1]: Still creating... [10s elapsed]
tencentcloud_cam_group_membership.group_membership_basic[0]: Still creating... [10s elapsed]
tencentcloud_cam_group_membership.group_membership_basic[0]: Creation complete after 10s [id=122792]
tencentcloud_cam_group_membership.group_membership_basic[1]: Creation complete after 10s [id=122792]

Apply complete! Resources: 7 added, 0 changed, 0 destroyed.
```
double apply

```
$ terraform apply
2020/04/13 12:25:07 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----
tencentcloud_cam_user.foo: Refreshing state... [id=cam-user-test22]
data.tencentcloud_instances.default: Refreshing state...
tencentcloud_cam_group.group_basic: Refreshing state... [id=122792]
tencentcloud_cam_user.user_basic: Refreshing state... [id=cam-user-test33]
tencentcloud_clb_attachment.default[1]: Refreshing state... [id=#lbl-g84n3gr2#lb-1sp4y4so]
tencentcloud_clb_attachment.default[0]: Refreshing state... [id=#lbl-g84n3gr2#lb-1sp4y4so]
tencentcloud_cam_group_membership.group_membership_basic[1]: Refreshing state... [id=122792]
tencentcloud_cam_group_membership.group_membership_basic[0]: Refreshing state... [id=122792]

Warning: Quoted type constraints are deprecated

  on variable.tf line 3, in variable "instance_ip":
   3:   type = "list"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "list" and write
list(string) instead to explicitly indicate that the list elements are
strings.


Apply complete! Resources: 0 added, 0 changed, 0 destroyed.`
```

destroy
```
terraform destroy
2020/04/13 12:24:27 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----
tencentcloud_cam_user.foo: Refreshing state... [id=cam-user-test22]
tencentcloud_cam_user.user_basic: Refreshing state... [id=cam-user-test33]
tencentcloud_cam_group.group_basic: Refreshing state... [id=122791]
data.tencentcloud_instances.default: Refreshing state...
tencentcloud_clb_attachment.default[1]: Refreshing state... [id=#lbl-g84n3gr2#lb-1sp4y4so]
tencentcloud_clb_attachment.default[0]: Refreshing state... [id=#lbl-g84n3gr2#lb-1sp4y4so]
tencentcloud_cam_group_membership.group_membership_basic[0]: Refreshing state... [id=122791]
tencentcloud_cam_group_membership.group_membership_basic[1]: Refreshing state... [id=122791]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # tencentcloud_cam_group.group_basic will be destroyed
  - resource "tencentcloud_cam_group" "group_basic" {
      - create_time = "2020-04-13 12:19:18" -> null
      - id          = "122791" -> null
      - name        = "cam-group-membership-test" -> null
      - remark      = "test" -> null
    }

  # tencentcloud_cam_group_membership.group_membership_basic[0] will be destroyed
  - resource "tencentcloud_cam_group_membership" "group_membership_basic" {
      - group_id = "122791" -> null
      - id       = "122791" -> null
      - user_ids = [
          - "cam-user-test33",
        ] -> null
    }

  # tencentcloud_cam_group_membership.group_membership_basic[1] will be destroyed
  - resource "tencentcloud_cam_group_membership" "group_membership_basic" {
      - group_id = "122791" -> null
      - id       = "122791" -> null
      - user_ids = [
          - "cam-user-test22",
        ] -> null
    }

  # tencentcloud_cam_user.foo will be destroyed
  - resource "tencentcloud_cam_user" "foo" {
      - console_login       = true -> null
      - country_code        = "86" -> null
      - email               = "1234@qq.com" -> null
      - force_delete        = true -> null
      - id                  = "cam-user-test22" -> null
      - name                = "cam-user-test22" -> null
      - need_reset_password = true -> null
      - password            = (sensitive value)
      - phone_num           = "12345678910" -> null
      - remark              = "test" -> null
      - secret_id           = (sensitive value)
      - secret_key          = (sensitive value)
      - uid                 = 6481953 -> null
      - uin                 = 100013789436 -> null
      - use_api             = true -> null
    }

  # tencentcloud_cam_user.user_basic will be destroyed
  - resource "tencentcloud_cam_user" "user_basic" {
      - console_login       = true -> null
      - country_code        = "86" -> null
      - email               = "1234@qq.com" -> null
      - force_delete        = true -> null
      - id                  = "cam-user-test33" -> null
      - name                = "cam-user-test33" -> null
      - need_reset_password = true -> null
      - password            = (sensitive value)
      - phone_num           = "12345678910" -> null
      - remark              = "test" -> null
      - secret_id           = (sensitive value)
      - secret_key          = (sensitive value)
      - uid                 = 6481952 -> null
      - uin                 = 100013789435 -> null
      - use_api             = true -> null
    }

  # tencentcloud_clb_attachment.default[0] will be destroyed
  - resource "tencentcloud_clb_attachment" "default" {
      - clb_id        = "lb-1sp4y4so" -> null
      - id            = "#lbl-g84n3gr2#lb-1sp4y4so" -> null
      - listener_id   = "lbl-g84n3gr2" -> null
      - protocol_type = "TCP" -> null

      - targets {
          - instance_id = "ins-bvpf6j4w" -> null
          - port        = 80 -> null
          - weight      = 10 -> null
        }
    }

  # tencentcloud_clb_attachment.default[1] will be destroyed
  - resource "tencentcloud_clb_attachment" "default" {
      - clb_id        = "lb-1sp4y4so" -> null
      - id            = "#lbl-g84n3gr2#lb-1sp4y4so" -> null
      - listener_id   = "lbl-g84n3gr2" -> null
      - protocol_type = "TCP" -> null

      - targets {
          - instance_id = "ins-fa2damgc" -> null
          - port        = 80 -> null
          - weight      = 10 -> null
        }
    }

Plan: 0 to add, 0 to change, 7 to destroy.


Warning: Quoted type constraints are deprecated

  on variable.tf line 3, in variable "instance_ip":
   3:   type = "list"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "list" and write
list(string) instead to explicitly indicate that the list elements are
strings.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

tencentcloud_cam_group_membership.group_membership_basic[0]: Destroying... [id=122791]
tencentcloud_cam_group_membership.group_membership_basic[1]: Destroying... [id=122791]
tencentcloud_clb_attachment.default[1]: Destroying... [id=#lbl-g84n3gr2#lb-1sp4y4so]
tencentcloud_clb_attachment.default[0]: Destroying... [id=#lbl-g84n3gr2#lb-1sp4y4so]
tencentcloud_cam_group_membership.group_membership_basic[1]: Destruction complete after 1s
tencentcloud_cam_group_membership.group_membership_basic[0]: Destruction complete after 1s
tencentcloud_cam_group.group_basic: Destroying... [id=122791]
tencentcloud_cam_user.user_basic: Destroying... [id=cam-user-test33]
tencentcloud_cam_user.foo: Destroying... [id=cam-user-test22]
tencentcloud_cam_group.group_basic: Destruction complete after 0s
tencentcloud_cam_user.foo: Destruction complete after 1s
tencentcloud_clb_attachment.default[1]: Destruction complete after 2s
tencentcloud_cam_user.user_basic: Destruction complete after 1s
tencentcloud_clb_attachment.default[0]: Destruction complete after 4s
Destroy complete! Resources: 7 destroyed.

```
