### PR TITLE
redis `type_id`,`redis_shard_num`,`redis_replicas_num` supports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-## 1.34.0 (Unreleased)
+## 1.33.1 (Unreleased)
+
+ENHANCEMENTS: 
+Resource: `tencentcloud_redis_instance` add new argument `type_id`,`redis_shard_num`,`redis_replicas_num`
+Data Source: `tencentcloud_redis_instances` add new argument  `type_id`,`redis_shard_num`,`redis_replicas_num`
+Data Source: `tencentcloud_redis_zone_config` add output argument `type_id` and new output argument  `type_id`,`redis_shard_nums`,`redis_replicas_nums`
+
+DEPRECATED:
+* Resource: `tencentcloud_redis_instance`: optional argument `type` is no longer supported, replace by `type_id`.
+* Data Source: `tencentcloud_redis_instances`: output argument `type` is no longer supported, replace by `type_id`
+* Data Source: `tencentcloud_redis_zone_config`: output argument `type` is no longer supported, replace by `type_id`
+
 ## 1.33.0 (May 18, 2020)
 
 FEATURES:

--- a/tencentcloud/connectivity/transport.go
+++ b/tencentcloud/connectivity/transport.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const ReqClient = "Terraform-v1.24.1"
+const ReqClient = "Terraform-v1.33.1"
 
 type LogRoundTripper struct {
 }
@@ -27,19 +27,20 @@ func (me *LogRoundTripper) RoundTrip(request *http.Request) (response *http.Resp
 	if errRet != nil {
 		return
 	}
-
+	var headName = "X-TC-Action"
 	request.Header.Set("X-TC-RequestClient", ReqClient)
-	inBytes = []byte(fmt.Sprintf("%s, request: ", request.Header["X-TC-Action"]))
+	inBytes = []byte(fmt.Sprintf("%s, request: ", request.Header[headName]))
 	requestBody, errRet := ioutil.ReadAll(bodyReader)
 	if errRet != nil {
 		return
 	}
 	inBytes = append(inBytes, requestBody...)
 
+	headName = "X-TC-Region"
 	appendMessage := []byte(fmt.Sprintf(
 		", (host %+v, region:%+v)",
 		request.Header["Host"],
-		request.Header["X-TC-Region"],
+		request.Header[headName],
 	))
 
 	inBytes = append(inBytes, appendMessage...)

--- a/tencentcloud/data_source_tc_redis_instances.go
+++ b/tencentcloud/data_source_tc_redis_instances.go
@@ -87,10 +87,26 @@ func dataSourceTencentRedisInstances() *schema.Resource {
 							Computed:    true,
 							Description: "ID of the project to which a redis instance belongs.",
 						},
+						"type_id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Instance type. Refer to `data.tencentcloud_redis_zone_config.list.type_id` get available values.",
+						},
 						"type": {
 							Type:        schema.TypeString,
 							Computed:    true,
+							Deprecated:  "It has been deprecated from version 1.33.1. Please use 'type_id' instead.",
 							Description: "Instance type. Available values: master_slave_redis, master_slave_ckv, cluster_ckv, cluster_redis and standalone_redis.",
+						},
+						"redis_shard_num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of instance shard.",
+						},
+						"redis_replicas_num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of instance copies.",
 						},
 						"mem_size": {
 							Type:        schema.TypeInt,
@@ -225,6 +241,9 @@ instanceLoop:
 		instanceDes["create_time"] = instance.CreateTime
 
 		instanceDes["tags"] = instance.Tags
+		instanceDes["redis_shard_num"] = instance.RedisShardNum
+		instanceDes["redis_replicas_num"] = instance.RedisReplicasNum
+		instanceDes["type_id"] = instance.TypeId
 
 		instanceList = append(instanceList, instanceDes)
 	}

--- a/tencentcloud/data_source_tc_redis_instances_test.go
+++ b/tencentcloud/data_source_tc_redis_instances_test.go
@@ -47,7 +47,7 @@ func testAccTencentCloudRedisInstancesDataSourceConfig() string {
 	return `
 resource "tencentcloud_redis_instance" "redis_instance_test" {
   availability_zone = "ap-guangzhou-3"
-  type              = "master_slave_redis"
+  type_id           = 2
   password          = "test12345789"
   mem_size          = 8192
   name              = "terraform_test"

--- a/tencentcloud/data_source_tc_redis_zone_config_test.go
+++ b/tencentcloud/data_source_tc_redis_zone_config_test.go
@@ -32,6 +32,8 @@ func TestAccDataSourceRedisZoneConfig_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.tencentcloud_redis_zone_config.testWithRegion", "list.0.type"),
 					resource.TestCheckResourceAttrSet("data.tencentcloud_redis_zone_config.testWithRegion", "list.0.version"),
 					resource.TestCheckResourceAttrSet("data.tencentcloud_redis_zone_config.testWithRegion", "list.0.mem_sizes.#"),
+					resource.TestCheckResourceAttrSet("data.tencentcloud_redis_zone_config.testWithRegion", "list.0.redis_shard_nums.#"),
+					resource.TestCheckResourceAttrSet("data.tencentcloud_redis_zone_config.testWithRegion", "list.0.redis_replicas_nums.#"),
 				),
 			},
 		},

--- a/tencentcloud/data_source_tc_redis_zone_config_test.go
+++ b/tencentcloud/data_source_tc_redis_zone_config_test.go
@@ -29,7 +29,7 @@ func TestAccDataSourceRedisZoneConfig_basic(t *testing.T) {
 					testAccCheckTencentCloudDataSourceID("data.tencentcloud_redis_zone_config.testWithRegion"),
 					resource.TestCheckResourceAttrSet("data.tencentcloud_redis_zone_config.testWithRegion", "list.#"),
 					resource.TestCheckResourceAttrSet("data.tencentcloud_redis_zone_config.testWithRegion", "list.0.zone"),
-					resource.TestCheckResourceAttrSet("data.tencentcloud_redis_zone_config.testWithRegion", "list.0.type"),
+					resource.TestCheckResourceAttrSet("data.tencentcloud_redis_zone_config.testWithRegion", "list.0.type_id"),
 					resource.TestCheckResourceAttrSet("data.tencentcloud_redis_zone_config.testWithRegion", "list.0.version"),
 					resource.TestCheckResourceAttrSet("data.tencentcloud_redis_zone_config.testWithRegion", "list.0.mem_sizes.#"),
 					resource.TestCheckResourceAttrSet("data.tencentcloud_redis_zone_config.testWithRegion", "list.0.redis_shard_nums.#"),

--- a/tencentcloud/resource_tc_redis_backup_config_test.go
+++ b/tencentcloud/resource_tc_redis_backup_config_test.go
@@ -95,6 +95,7 @@ func testAccRedisBackupConfigUpdate() string {
 	return fmt.Sprintf(`
 resource "tencentcloud_redis_instance" "redis_instance_test" {
   availability_zone = "ap-guangzhou-3"
+  type_id           = 2 
   password          = "test12345789"
   mem_size          = 8192
   name              = "terrform_test"
@@ -110,6 +111,7 @@ func testAccRedisBackupConfig() string {
 	return fmt.Sprintf(`
 resource "tencentcloud_redis_instance" "redis_instance_test" {
   availability_zone = "ap-guangzhou-3"
+  type_id           = 2 
   password          = "test12345789"
   mem_size          = 8192
   name              = "terrform_test"

--- a/tencentcloud/resource_tc_redis_instance_test.go
+++ b/tencentcloud/resource_tc_redis_instance_test.go
@@ -23,10 +23,13 @@ func TestAccTencentCloudRedisInstance(t *testing.T) {
 					resource.TestCheckResourceAttrSet("tencentcloud_redis_instance.redis_instance_test", "ip"),
 					resource.TestCheckResourceAttrSet("tencentcloud_redis_instance.redis_instance_test", "create_time"),
 					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "port", "6379"),
-					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "type", "master_slave_redis"),
+					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "type_id", "2"),
+					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "redis_shard_num", "1"),
+					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "redis_replicas_num", "1"),
 					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "mem_size", "8192"),
 					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "name", "terrform_test"),
 					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "project_id", "0"),
+					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "status", "online"),
 					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "status", "online"),
 				),
 			},
@@ -52,7 +55,9 @@ func TestAccTencentCloudRedisInstance(t *testing.T) {
 					resource.TestCheckResourceAttrSet("tencentcloud_redis_instance.redis_instance_test", "ip"),
 					resource.TestCheckResourceAttrSet("tencentcloud_redis_instance.redis_instance_test", "create_time"),
 					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "port", "6379"),
-					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "type", "master_slave_redis"),
+					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "type_id", "2"),
+					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "redis_shard_num", "1"),
+					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "redis_replicas_num", "1"),
 					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "mem_size", "8192"),
 					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "name", "terrform_test_update"),
 					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "project_id", "0"),
@@ -66,7 +71,10 @@ func TestAccTencentCloudRedisInstance(t *testing.T) {
 					resource.TestCheckResourceAttrSet("tencentcloud_redis_instance.redis_instance_test", "ip"),
 					resource.TestCheckResourceAttrSet("tencentcloud_redis_instance.redis_instance_test", "create_time"),
 					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "port", "6379"),
-					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "type", "master_slave_redis"),
+					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "type_id", "2"),
+					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "redis_shard_num", "1"),
+					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "redis_replicas_num", "1"),
+					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "type_id", "2"),
 					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "mem_size", "12288"),
 					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "name", "terrform_test_update"),
 					resource.TestCheckResourceAttr("tencentcloud_redis_instance.redis_instance_test", "project_id", "0"),
@@ -77,7 +85,7 @@ func TestAccTencentCloudRedisInstance(t *testing.T) {
 				ResourceName:            "tencentcloud_redis_instance.redis_instance_test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"password"},
+				ImportStateVerifyIgnore: []string{"password", "type", "redis_shard_num", "redis_replicas_num"},
 			},
 		},
 	})
@@ -138,12 +146,14 @@ func testAccTencentCloudRedisInstanceDestroy(s *terraform.State) error {
 func testAccRedisInstanceBasic() string {
 	return `
 resource "tencentcloud_redis_instance" "redis_instance_test" {
-  availability_zone = "ap-guangzhou-3"
-  type              = "master_slave_redis"
-  password          = "test12345789"
-  mem_size          = 8192
-  name              = "terrform_test"
-  port              = 6379
+  availability_zone  = "ap-guangzhou-3"
+  type_id            = 2
+  password           = "test12345789"
+  mem_size           = 8192
+  name               = "terrform_test"
+  port               = 6379
+  redis_shard_num    = 1
+  redis_replicas_num = 1
 }`
 }
 
@@ -151,12 +161,13 @@ func testAccRedisInstanceTags() string {
 	return `
 resource "tencentcloud_redis_instance" "redis_instance_test" {
   availability_zone = "ap-guangzhou-3"
-  type              = "master_slave_redis"
-  password          = "test12345789"
-  mem_size          = 8192
-  name              = "terrform_test"
-  port              = 6379
-
+  type_id            = 2
+  password           = "test12345789"
+  mem_size           = 8192
+  name               = "terrform_test"
+  port               = 6379
+  redis_shard_num    = 1
+  redis_replicas_num = 1
   tags = {
     "test" = "test"
   }
@@ -166,13 +177,14 @@ resource "tencentcloud_redis_instance" "redis_instance_test" {
 func testAccRedisInstanceTagsUpdate() string {
 	return `
 resource "tencentcloud_redis_instance" "redis_instance_test" {
-  availability_zone = "ap-guangzhou-3"
-  type              = "master_slave_redis"
-  password          = "test12345789"
-  mem_size          = 8192
-  name              = "terrform_test"
-  port              = 6379
-
+  availability_zone  = "ap-guangzhou-3"
+  type_id            = 2
+  password           = "test12345789"
+  mem_size           = 8192
+  name               = "terrform_test"
+  port               = 6379
+  redis_shard_num    = 1
+  redis_replicas_num = 1
   tags = {
     "abc" = "abc"
   }
@@ -182,13 +194,14 @@ resource "tencentcloud_redis_instance" "redis_instance_test" {
 func testAccRedisInstanceUpdateName() string {
 	return `
 resource "tencentcloud_redis_instance" "redis_instance_test" {
-  availability_zone = "ap-guangzhou-3"
-  type              = "master_slave_redis"
-  password          = "test12345789"
-  mem_size          = 8192
-  name              = "terrform_test_update"
-  port              = 6379
-
+  availability_zone  = "ap-guangzhou-3"
+  type_id            = 2
+  password           = "test12345789"
+  mem_size           = 8192
+  name               = "terrform_test_update"
+  port               = 6379
+  redis_shard_num    = 1
+  redis_replicas_num = 1
   tags = {
     "abc" = "abc"
   }
@@ -199,11 +212,13 @@ func testAccRedisInstanceUpdateMemsizeAndPassword() string {
 	return `
 resource "tencentcloud_redis_instance" "redis_instance_test" {
   availability_zone = "ap-guangzhou-3"
-  type              = "master_slave_redis"
-  password          = "AAA123456BBB"
-  mem_size          = 12288
-  name              = "terrform_test_update"
-  port              = 6379
+  type_id            = 2
+  password           = "AAA123456BBB"
+  mem_size           = 12288
+  name               = "terrform_test_update"
+  port               = 6379
+  redis_shard_num    = 1
+  redis_replicas_num = 1
 
   tags = {
     "abc" = "abc"

--- a/website/docs/d/redis_instances.html.markdown
+++ b/website/docs/d/redis_instances.html.markdown
@@ -45,10 +45,13 @@ In addition to all arguments above, the following attributes are exported:
   * `port` - The port used to access a redis instance.
   * `project_id` - ID of the project to which a redis instance belongs.
   * `redis_id` - ID of a redis instance.
+  * `redis_replicas_num` - The number of instance copies.
+  * `redis_shard_num` - The number of instance shard.
   * `status` - Current status of an instance, maybe: init, processing, online, isolate and todelete.
   * `subnet_id` - ID of the vpc subnet.
   * `tags` - Tags of an instance.
-  * `type` - Instance type. Available values: master_slave_redis, master_slave_ckv, cluster_ckv, cluster_redis and standalone_redis.
+  * `type_id` - Instance type. Refer to `data.tencentcloud_redis_zone_config.list.type_id` get available values.
+  * `type` - (**Deprecated**) It has been deprecated from version 1.33.1. Please use 'type_id' instead. Instance type. Available values: master_slave_redis, master_slave_ckv, cluster_ckv, cluster_redis and standalone_redis.
   * `vpc_id` - ID of the vpc with which the instance is associated.
   * `zone` - Available zone to which a redis instance belongs.
 

--- a/website/docs/d/redis_zone_config.html.markdown
+++ b/website/docs/d/redis_zone_config.html.markdown
@@ -25,6 +25,7 @@ The following arguments are supported:
 
 * `region` - (Optional) Name of a region. If this value is not set, the current region getting from provider's configuration will be used.
 * `result_output_file` - (Optional) Used to save results.
+* `type_id` - (Optional) Instance type id.
 
 ## Attributes Reference
 
@@ -32,7 +33,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `list` - A list of zone. Each element contains the following attributes:
   * `mem_sizes` - The memory volume of an available instance(in MB).
-  * `type` - Instance type. Available values: master_slave_redis, master_slave_ckv, cluster_ckv, cluster_redis and standalone_redis.
+  * `redis_replicas_nums` - The support numbers of instance copies.
+  * `redis_shard_nums` - The support numbers of instance shard.
+  * `type_id` - Instance type. Which redis type supports in this zone.
+  * `type` - (**Deprecated**) It has been deprecated from version 1.33.1. Please use 'type_id' instead. Instance type. Available values: master_slave_redis, master_slave_ckv, cluster_ckv, cluster_redis and standalone_redis.
   * `version` - Version description of an available instance. Possible values: Redis 3.2, Redis 4.0.
   * `zone` - ID of available zone.
 

--- a/website/docs/r/monitor_policy_group.html.markdown
+++ b/website/docs/r/monitor_policy_group.html.markdown
@@ -63,11 +63,11 @@ The following arguments are supported:
 
 The `conditions` object supports the following:
 
-* `alarm_notify_period` - (Required) Alarm sending cycle per second.<0 does not fire, 0 only fires once, and >0 fires every triggerTime second.
+* `alarm_notify_period` - (Required) Alarm sending cycle per second. <0 does not fire, 0 only fires once, and >0 fires every triggerTime second.
 * `alarm_notify_type` - (Required) Alarm sending convergence type. 0 continuous alarm, 1 index alarm.
-* `metric_id` - (Required) Id of the metric.refer to `data.tencentcloud_monitor_policy_conditions(metric_id)`.
+* `metric_id` - (Required) Id of the metric, refer to `data.tencentcloud_monitor_policy_conditions(metric_id)`.
 * `calc_period` - (Optional) Data aggregation cycle (unit of second), if the metric has a default value can not be filled, refer to `data.tencentcloud_monitor_policy_conditions(period_keys)`.
-* `calc_type` - (Optional) Compare type, 1 means more than, 2  means greater than or equal, 3 means less than, 4 means less than or equal to, 5 means equal, 6 means not equal, 7 means days rose, 8 means days fell, 9 means weeks rose, 10  means weeks fell, 11 means period rise, 12 means period fell. refer to `data.tencentcloud_monitor_policy_conditions(calc_type_keys)`.
+* `calc_type` - (Optional) Compare type, 1 means more than, 2  means greater than or equal, 3 means less than, 4 means less than or equal to, 5 means equal, 6 means not equal, 7 means days rose, 8 means days fell, 9 means weeks rose, 10  means weeks fell, 11 means period rise, 12 means period fell, refer to `data.tencentcloud_monitor_policy_conditions(calc_type_keys)`.
 * `calc_value` - (Optional) Threshold value, refer to `data.tencentcloud_monitor_policy_conditions(calc_value_*)`.
 * `continue_period` - (Optional) The rule triggers an alert that lasts for several detection cycles, refer to `data.tencentcloud_monitor_policy_conditions(period_num_keys)`.
 

--- a/website/docs/r/redis_instance.html.markdown
+++ b/website/docs/r/redis_instance.html.markdown
@@ -13,13 +13,18 @@ Provides a resource to create a Redis instance and set its attributes.
 ## Example Usage
 
 ```hcl
-resource "tencentcloud_redis_instance" "redis_instance_test" {
-  availability_zone = "ap-hongkong-3"
-  type              = "master_slave_redis"
-  password          = "test12345789"
-  mem_size          = 8192
-  name              = "terrform_test"
-  port              = 6379
+data "tencentcloud_redis_zone_config" "zone" {
+}
+
+resource "tencentcloud_redis_instance" "redis_instance_test_2" {
+  availability_zone  = data.tencentcloud_redis_zone_config.zone.list[0].zone
+  type_id            = data.tencentcloud_redis_zone_config.zone.list[0].type_id
+  password           = "test12345789"
+  mem_size           = 8192
+  redis_shard_num    = data.tencentcloud_redis_zone_config.zone.list[0].redis_shard_nums[0]
+  redis_replicas_num = data.tencentcloud_redis_zone_config.zone.list[0].redis_replicas_nums[0]
+  name               = "terrform_test"
+  port               = 6379
 }
 ```
 
@@ -33,10 +38,13 @@ The following arguments are supported:
 * `name` - (Optional) Instance name.
 * `port` - (Optional, ForceNew) The port used to access a redis instance. The default value is 6379. And this value can't be changed after creation, or the Redis instance will be recreated.
 * `project_id` - (Optional) Specifies which project the instance should belong to.
+* `redis_replicas_num` - (Optional, ForceNew) The number of instance copies. This is not required for standalone and master slave versions.
+* `redis_shard_num` - (Optional, ForceNew) The number of instance shard. This is not required for standalone and master slave versions.
 * `security_groups` - (Optional, ForceNew) ID of security group. If both vpc_id and subnet_id are not set, this argument should not be set either.
 * `subnet_id` - (Optional, ForceNew) Specifies which subnet the instance should belong to.
 * `tags` - (Optional) Instance tags.
-* `type` - (Optional, ForceNew) Instance type. Available values: `cluster_ckv`,`cluster_redis5.0`,`cluster_redis`,`master_slave_ckv`,`master_slave_redis5.0`,`master_slave_redis`,`standalone_redis`, specific region support specific types, need to refer data `tencentcloud_redis_zone_config`.
+* `type_id` - (Optional, ForceNew) Instance type. Refer to `data.tencentcloud_redis_zone_config.list.type_id` get available values.
+* `type` - (Optional, ForceNew, **Deprecated**) It has been deprecated from version 1.33.1. Please use 'type_id' instead. Instance type. Available values: `cluster_ckv`,`cluster_redis5.0`,`cluster_redis`,`master_slave_ckv`,`master_slave_redis5.0`,`master_slave_redis`,`standalone_redis`, specific region support specific types, need to refer data `tencentcloud_redis_zone_config`.
 * `vpc_id` - (Optional, ForceNew) ID of the vpc with which the instance is to be associated.
 
 ## Attributes Reference


### PR DESCRIPTION
ENHANCEMENTS: 
Resource: `tencentcloud_redis_instance` add new argument `type_id`,`redis_shard_num`,`redis_replicas_num`
Data Source: `tencentcloud_redis_instances` add new argument  `type_id`,`redis_shard_num`,`redis_replicas_num`
Data Source: `tencentcloud_redis_zone_config` add output argument `type_id` and new output argument  `type_id`,`redis_shard_nums`,`redis_replicas_nums`

DEPRECATED:
* Resource: `tencentcloud_redis_instance`: optional argument `type` is no longer supported, replace by `type_id`.
* Data Source: `tencentcloud_redis_instances`: output argument `type` is no longer supported, replace by `type_id`
* Data Source: `tencentcloud_redis_zone_config`: output argument `type` is no longer supported, replace by `type_id`
------------------------------------------------------------------------------
=== RUN   TestAccTencentCloudRedisInstancesDataSource
--- PASS: TestAccTencentCloudRedisInstancesDataSource (49.39s)
=== RUN   TestAccTencentCloudRedisInstance
--- PASS: TestAccTencentCloudRedisInstance (70.04s)
=== RUN   TestAccTencentCloudRedisBackupConfig
--- PASS: TestAccTencentCloudRedisBackupConfig (49.01s)
=== RUN   TestAccDataSourceRedisZoneConfig_basic
--- PASS: TestAccDataSourceRedisZoneConfig_basic (1.67s)

#410