### PR TITLE
fix pass case

### DIFF
--- a/tencentcloud/resource_tc_cbs_storage.go
+++ b/tencentcloud/resource_tc_cbs_storage.go
@@ -32,7 +32,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -443,16 +442,15 @@ func resourceTencentCloudCbsStorageUpdate(d *schema.ResourceData, meta interface
 		if err != nil {
 			return err
 		}
-		//to pay order wait
-		time.Sleep(readRetryTimeout)
+
 		//check charge Type
 		err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
 			storage, e := cbsService.DescribeDiskById(ctx, storageId)
 			if e != nil {
 				return retryError(e)
 			}
-			if storage != nil && *storage.DiskState == CBS_STORAGE_STATUS_EXPANDING {
-				return resource.RetryableError(fmt.Errorf("cbs storage status is %s", *storage.DiskState))
+			if storage != nil && (*storage.DiskState == CBS_STORAGE_STATUS_EXPANDING || *storage.DiskChargeType != CBS_CHARGE_TYPE_PREPAID) {
+				return resource.RetryableError(fmt.Errorf("cbs storage status is %s, charget type is %s", *storage.DiskState, *storage.DiskChargeType))
 			}
 			return nil
 		})
@@ -477,9 +475,21 @@ func resourceTencentCloudCbsStorageUpdate(d *schema.ResourceData, meta interface
 			if err != nil {
 				return err
 			}
-
-			//to pay order wait
-			time.Sleep(readRetryTimeout)
+			//check renew flag
+			err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
+				storage, e := cbsService.DescribeDiskById(ctx, storageId)
+				if e != nil {
+					return retryError(e)
+				}
+				if storage != nil && (*storage.DiskState == CBS_STORAGE_STATUS_EXPANDING || *storage.RenewFlag != renewFlag) {
+					return resource.RetryableError(fmt.Errorf("cbs storage status is %s, renew flag is %s", *storage.DiskState, *storage.RenewFlag))
+				}
+				return nil
+			})
+			if err != nil {
+				log.Printf("[CRITAL]%s update cbs failed, reason:%s\n ", logId, err.Error())
+				return err
+			}
 			d.SetPartial("prepaid_renew_flag")
 
 		}

--- a/tencentcloud/resource_tc_cbs_storage.go
+++ b/tencentcloud/resource_tc_cbs_storage.go
@@ -443,7 +443,8 @@ func resourceTencentCloudCbsStorageUpdate(d *schema.ResourceData, meta interface
 		if err != nil {
 			return err
 		}
-
+		//to pay order wait
+		time.Sleep(readRetryTimeout)
 		//check charge Type
 		err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
 			storage, e := cbsService.DescribeDiskById(ctx, storageId)

--- a/tencentcloud/resource_tc_cbs_storage_test.go
+++ b/tencentcloud/resource_tc_cbs_storage_test.go
@@ -28,9 +28,10 @@ func TestAccTencentCloudCbsStorage_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "tencentcloud_cbs_storage.storage_basic",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "tencentcloud_cbs_storage.storage_basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_delete"},
 			},
 		},
 	})


### PR DESCRIPTION
fix bug that changing pay type did not work and the basic case did not pass

```
$ make testacc TESTARGS=" -run=TestAccTencentCloudCbsStorage_upgrade"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudCbsStorage_upgrade -timeout 120m
?       github.com/terraform-providers/terraform-provider-tencentcloud  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/gendoc   (cached) [no tests to run]
=== RUN   TestAccTencentCloudCbsStorage_upgrade
=== PAUSE TestAccTencentCloudCbsStorage_upgrade
=== CONT  TestAccTencentCloudCbsStorage_upgrade
--- PASS: TestAccTencentCloudCbsStorage_upgrade (186.81s)
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud     187.603s
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/connectivity        [no test files]
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/internal/helper     [no test files]
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/ratelimit   [no test files]

```


```
 make testacc TESTARGS=" -run=TestAccTencentCloudCbsStorage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudCbsStorage_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-tencentcloud  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/gendoc   (cached) [no tests to run]
=== RUN   TestAccTencentCloudCbsStorage_basic
=== PAUSE TestAccTencentCloudCbsStorage_basic
=== CONT  TestAccTencentCloudCbsStorage_basic
--- PASS: TestAccTencentCloudCbsStorage_basic (2.43s)
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud     3.155s
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/connectivity        [no test files]
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/internal/helper     [no test files]
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/ratelimit   [no test files]

```