### PR TITLE
support when the client certificate id is empty

### DIFF
--- a/tencentcloud/resource_tc_gaap_http_domain.go
+++ b/tencentcloud/resource_tc_gaap_http_domain.go
@@ -338,9 +338,14 @@ func resourceTencentCloudGaapHttpDomainRead(d *schema.ResourceData, m interface{
 	}
 	_ = d.Set("certificate_id", httpDomain.CertificateId)
 
-	clientCertificateIds := make([]*string, 0, len(httpDomain.PolyClientCertificateAliasInfo))
-	for _, info := range httpDomain.PolyClientCertificateAliasInfo {
-		clientCertificateIds = append(clientCertificateIds, info.CertificateId)
+	var clientCertificateIds []*string
+	if httpDomain.PolyClientCertificateAliasInfo != nil {
+		clientCertificateIds = make([]*string, 0, len(httpDomain.PolyClientCertificateAliasInfo))
+		for _, info := range httpDomain.PolyClientCertificateAliasInfo {
+			clientCertificateIds = append(clientCertificateIds, info.CertificateId)
+		}
+	} else {
+		clientCertificateIds = []*string{helper.String("default")}
 	}
 
 	_ = d.Set("client_certificate_id", clientCertificateIds[0])


### PR DESCRIPTION
In case of some one-way https listener domains created in the past, the client certificate id is empty string and cannot be modified to "default".

The https listeners which use one-way authentication could not be modified to two-way authentication.

When the client certificate id is empty string,  `terraform plan` failed with following errors.
```
 runtime error: index out of range [0] with length 0
2020-06-02T22:22:05.352+0900 [DEBUG] plugin.terraform-provider-tencentcloud_v1.35.0_x4: 
2020-06-02T22:22:05.352+0900 [DEBUG] plugin.terraform-provider-tencentcloud_v1.35.0_x4: goroutine 694 [running]:
2020-06-02T22:22:05.352+0900 [DEBUG] plugin.terraform-provider-tencentcloud_v1.35.0_x4: github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud.resourceTencentCloudGaapHttpDomainRead(0xc0002944d0, 0x225ec00, 0xc00012ec90, 0x0, 0x0)
2020-06-02T22:22:05.352+0900 [DEBUG] plugin.terraform-provider-tencentcloud_v1.35.0_x4:         /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/resource_tc_gaap_http_domain.go:346 +0xd3b
```

I fix it and apologies that I could not run tests.