### PR TITLE
Fix cvm instance inconsistency when eip is attached to the cvm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES:
 
 * **New Data Source**: `tencentcloud_availability_regions`
 
+BUG FIXES:
+
+* Resource: `tencentcloud_instance` fix `allocate_public_ip` inconsistency when eip is attached to the cvm.
+
 ## 1.35.1 (June 02, 2020)
 
 ENHANCEMENTS: 

--- a/tencentcloud/connectivity/client.go
+++ b/tencentcloud/connectivity/client.go
@@ -97,7 +97,7 @@ func (me *TencentCloudClient) UseCosClient() *s3.S3 {
 	resolver := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
 		if service == endpoints.S3ServiceID {
 			return endpoints.ResolvedEndpoint{
-				URL:           fmt.Sprintf("http://cos.%s.myqcloud.com", region),
+				URL:           fmt.Sprintf("https://cos.%s.myqcloud.com", region),
 				SigningRegion: region,
 			}, nil
 		}

--- a/tencentcloud/resource_tc_instance.go
+++ b/tencentcloud/resource_tc_instance.go
@@ -87,6 +87,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
 	cvm "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312"
+	vpc "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312"
 	"github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/internal/helper"
 	"github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/ratelimit"
 )
@@ -635,12 +636,12 @@ func resourceTencentCloudInstanceRead(d *schema.ResourceData, meta interface{}) 
 		_ = d.Set("force_delete", forceDelete)
 	}
 
+	client := meta.(*TencentCloudClient).apiV3Conn
 	cvmService := CvmService{
-		client: meta.(*TencentCloudClient).apiV3Conn,
+		client: client,
 	}
-
 	tkeService := TkeService{
-		client: meta.(*TencentCloudClient).apiV3Conn,
+		client: client,
 	}
 	var instance *cvm.Instance
 	var errRet error
@@ -693,7 +694,28 @@ func resourceTencentCloudInstanceRead(d *schema.ResourceData, meta interface{}) 
 	_ = d.Set("instance_status", instance.InstanceState)
 	_ = d.Set("create_time", instance.CreatedTime)
 	_ = d.Set("expired_time", instance.ExpiredTime)
-	_ = d.Set("allocate_public_ip", len(instance.PublicIpAddresses) > 0)
+
+	if len(instance.PublicIpAddresses) > 0 {
+		vpcService := VpcService{client: client}
+		filter := map[string][]string{
+			"address-ip": {*instance.PublicIpAddresses[0]},
+		}
+		var eips []*vpc.Address
+		var errRet error
+		err := resource.Retry(readRetryTimeout, func() *resource.RetryError {
+			eips, errRet = vpcService.DescribeEipByFilter(ctx, filter)
+			if errRet != nil {
+				return retryError(errRet, InternalError)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		_ = d.Set("allocate_public_ip", len(eips) < 1)
+	} else {
+		_ = d.Set("allocate_public_ip", false)
+	}
 
 	// as attachment add tencentcloud:autoscaling:auto-scaling-group-id tag automatically
 	// we should remove this tag, otherwise it will cause terraform state change


### PR DESCRIPTION
make testacc TESTARGS=" -run=TestAccTencentCloudEipAssociationWithInstance"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudEipAssociationWithInstance -timeout 120m
?       github.com/terraform-providers/terraform-provider-tencentcloud  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/gendoc   (cached) [no tests to run]
=== RUN   TestAccTencentCloudEipAssociationWithInstance
--- PASS: TestAccTencentCloudEipAssociationWithInstance (52.17s)
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud     52.190s