### PR TITLE
fix deal error for  kubernetes as group Read

### DIFF
--- a/tencentcloud/resource_tc_kubernetes_as_scaling_group.go
+++ b/tencentcloud/resource_tc_kubernetes_as_scaling_group.go
@@ -736,11 +736,14 @@ func resourceKubernetesAsScalingGroupRead(d *schema.ResourceData, meta interface
 		return nil
 	})
 
+	if err != nil {
+		return err
+	}
+
 	if clusterAsGroupSet == nil {
 		d.SetId("")
 	}
-
-	return err
+	return nil
 }
 
 func resourceKubernetesAsScalingGroupCreate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
fix small logic issues.
***
$ make testacc TESTARGS=" -run=TestAccTencentCloudTkeAsResource"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudTkeAsResource -timeout 120m
?   	github.com/terraform-providers/terraform-provider-tencentcloud	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-tencentcloud/gendoc	0.018s [no tests to run]
=== RUN   TestAccTencentCloudTkeAsResource
--- PASS: TestAccTencentCloudTkeAsResource (175.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud	175.114s
?   	github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/connectivity	[no test files]
?   	github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/internal/helper	[no test files]
?   	github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/ratelimit	[no test files]