### PR TITLE
cos bucket support encryption and versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-## 1.37.0 (Unreleased)
+## 1.36.1 (Unreleased)
 
 ENHANCEMENTS:
 
-* Resource： `tencentcloud_kubernetes_cluster` add new argument `labels`.
-* Resource： `tencentcloud_kubernetes_as_scaling_group` add new argument `labels`.
+* Resource: `tencentcloud_kubernetes_cluster` add new argument `labels`.
+* Resource: `tencentcloud_kubernetes_as_scaling_group` add new argument `labels`.
+* Resource: `tencentcloud_cos_bucket` add new arguments `encryption_algorithm` and `versioning_enable`.
 
 ## 1.36.0 (June 08, 2020)
 

--- a/tencentcloud/resource_tc_cos_bucket.go
+++ b/tencentcloud/resource_tc_cos_bucket.go
@@ -132,6 +132,17 @@ func resourceTencentCloudCosBucket() *schema.Resource {
 				}),
 				Description: "The canned ACL to apply. Available values include private, public-read, and public-read-write. Defaults to private.",
 			},
+			"encryption_algorithm": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The server-side encryption algorithm to use. Valid value is `AES256`.",
+			},
+			"versioning_enable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Enable bucket versioning.",
+			},
 			"cors_rules": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -344,13 +355,32 @@ func resourceTencentCloudCosBucketRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("setting website error: %v", err)
 	}
 
+	// read the encryption algorithm
+	encryption, err := cosService.GetBucketEncryption(ctx, bucket)
+	if err != nil {
+		return err
+	}
+	if err = d.Set("encryption_algorithm", encryption); err != nil {
+		return fmt.Errorf("setting encryption error: %v", err)
+	}
+
+	// read the versioning
+	versioning, err := cosService.GetBucketVersioning(ctx, bucket)
+	if err != nil {
+		return err
+	}
+	if err = d.Set("versioning_enable", versioning); err != nil {
+		return fmt.Errorf("setting versioning_enable error: %v", err)
+	}
+
 	// read the tags
 	tags, err := cosService.GetBucketTags(ctx, bucket)
 	if err != nil {
 		return fmt.Errorf("get tags failed: %v", err)
 	}
-
-	_ = d.Set("tags", tags)
+	if len(tags) > 0 {
+		_ = d.Set("tags", tags)
+	}
 
 	return nil
 }
@@ -364,6 +394,11 @@ func resourceTencentCloudCosBucketUpdate(d *schema.ResourceData, meta interface{
 	client := meta.(*TencentCloudClient).apiV3Conn.UseCosClient()
 
 	d.Partial(true)
+
+	err := resourceTencentCloudCosBucketEncryptionUpdate(ctx, client, d)
+	if err != nil {
+		return err
+	}
 
 	if d.HasChange("acl") {
 		err := resourceTencentCloudCosBucketAclUpdate(ctx, client, d)
@@ -395,6 +430,22 @@ func resourceTencentCloudCosBucketUpdate(d *schema.ResourceData, meta interface{
 			return err
 		}
 		d.SetPartial("website")
+	}
+
+	if d.HasChange("encryption_algorithm") {
+		err := resourceTencentCloudCosBucketEncryptionUpdate(ctx, client, d)
+		if err != nil {
+			return err
+		}
+		d.SetPartial("encryption_algorithm")
+	}
+
+	if d.HasChange("versioning_enable") {
+		err := resourceTencentCloudCosBucketVersioningUpdate(ctx, client, d)
+		if err != nil {
+			return err
+		}
+		d.SetPartial("versioning_enable")
 	}
 
 	if d.HasChange("tags") {
@@ -435,6 +486,80 @@ func resourceTencentCloudCosBucketDelete(d *schema.ResourceData, meta interface{
 	// wait for update cache
 	// if not, head bucket may be successful
 	time.Sleep(3 * time.Second)
+
+	return nil
+}
+
+func resourceTencentCloudCosBucketEncryptionUpdate(ctx context.Context, client *s3.S3, d *schema.ResourceData) error {
+	logId := getLogId(ctx)
+
+	bucket := d.Get("bucket").(string)
+	encryption := d.Get("encryption_algorithm").(string)
+	if encryption == "" {
+		request := s3.DeleteBucketEncryptionInput{
+			Bucket: aws.String(bucket),
+		}
+		response, err := client.DeleteBucketEncryption(&request)
+		if err != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+				logId, "delete bucket encryption", request.String(), err.Error())
+			return fmt.Errorf("cos delete bucket error: %s, bucket: %s", err.Error(), bucket)
+		}
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+			logId, "delete bucket encryption", request.String(), response.String())
+
+		return nil
+	}
+
+	request := s3.PutBucketEncryptionInput{
+		Bucket: aws.String(bucket),
+	}
+	request.ServerSideEncryptionConfiguration = &s3.ServerSideEncryptionConfiguration{}
+	rules := make([]*s3.ServerSideEncryptionRule, 0)
+	defaultRule := &s3.ServerSideEncryptionByDefault{
+		SSEAlgorithm: aws.String(encryption),
+	}
+	rule := &s3.ServerSideEncryptionRule{
+		ApplyServerSideEncryptionByDefault: defaultRule,
+	}
+	rules = append(rules, rule)
+	request.ServerSideEncryptionConfiguration.Rules = rules
+
+	response, err := client.PutBucketEncryption(&request)
+	if err != nil {
+		log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+			logId, "put bucket encryption", request.String(), err.Error())
+		return fmt.Errorf("cos put bucket encryption error: %s, bucket: %s", err.Error(), bucket)
+	}
+	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+		logId, "put bucket encryption", request.String(), response.String())
+
+	return nil
+}
+
+func resourceTencentCloudCosBucketVersioningUpdate(ctx context.Context, client *s3.S3, d *schema.ResourceData) error {
+	logId := getLogId(ctx)
+
+	bucket := d.Get("bucket").(string)
+	versioning := d.Get("versioning_enable").(bool)
+	status := "Suspended"
+	if versioning {
+		status = "Enabled"
+	}
+	request := s3.PutBucketVersioningInput{
+		Bucket: aws.String(bucket),
+		VersioningConfiguration: &s3.VersioningConfiguration{
+			Status: aws.String(status),
+		},
+	}
+	response, err := client.PutBucketVersioning(&request)
+	if err != nil {
+		log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+			logId, "put bucket encryption", request.String(), err.Error())
+		return fmt.Errorf("cos put bucket encryption error: %s, bucket: %s", err.Error(), bucket)
+	}
+	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+		logId, "put bucket encryption", request.String(), response.String())
 
 	return nil
 }

--- a/tencentcloud/resource_tc_cos_bucket_test.go
+++ b/tencentcloud/resource_tc_cos_bucket_test.go
@@ -80,6 +80,8 @@ func TestAccTencentCloudCosBucket_basic(t *testing.T) {
 				Config: testAccCosBucket_basicUpdate(appid),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCosBucketExists("tencentcloud_cos_bucket.bucket_basic"),
+					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_basic", "encryption_algorithm", "AES256"),
+					resource.TestCheckResourceAttr("tencentcloud_cos_bucket.bucket_basic", "versioning_enable", "true"),
 				),
 			},
 			{
@@ -314,8 +316,10 @@ resource "tencentcloud_cos_bucket" "bucket_basic" {
 func testAccCosBucket_basicUpdate(appid string) string {
 	return fmt.Sprintf(`
 resource "tencentcloud_cos_bucket" "bucket_basic" {
-  bucket = "tf-bucket-basic-%s"
-  acl    = "private"
+  bucket               = "tf-bucket-basic-%s"
+  acl                  = "private"
+  encryption_algorithm = "AES256"
+  versioning_enable    = true
 }
 `, appid)
 }

--- a/tencentcloud/resource_tc_scf_function.go
+++ b/tencentcloud/resource_tc_scf_function.go
@@ -132,8 +132,8 @@ func resourceTencentCloudScfFunction() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      3,
-				ValidateFunc: validateIntegerInRange(1, 300),
-				Description:  "Timeout of the SCF function, unit is second. Default `3`. Available value is 1-300.",
+				ValidateFunc: validateIntegerInRange(1, 900),
+				Description:  "Timeout of the SCF function, unit is second. Default `3`. Available value is 1-900.",
 			},
 			"environment": {
 				Type:        schema.TypeMap,

--- a/tencentcloud/resource_tc_ssl_certificate.go
+++ b/tencentcloud/resource_tc_ssl_certificate.go
@@ -230,7 +230,7 @@ func resourceTencentCloudSslCertificateRead(d *schema.ResourceData, m interface{
 		return err
 	}
 	_ = d.Set("project_id", projectId)
-	_ = d.Set("cert", certificate.Cert)
+	_ = d.Set("cert", strings.TrimRight(*certificate.Cert, "\n"))
 	_ = d.Set("product_zh_name", certificate.ProductZhName)
 	_ = d.Set("domain", certificate.Domain)
 	_ = d.Set("status", certificate.Status)

--- a/tencentcloud/service_tencentcloud_cos.go
+++ b/tencentcloud/service_tencentcloud_cos.go
@@ -358,12 +358,12 @@ func (me *CosService) GetBucketWebsite(ctx context.Context, bucket string) (webs
 	response, err := me.client.UseCosClient().GetBucketWebsite(&request)
 	if err != nil {
 		awsError, ok := err.(awserr.Error)
-		if !ok || awsError.Code() != "NoSuchWebsiteConfiguration" {
-			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
-				logId, "get bucket website", request.String(), err.Error())
-			errRet = fmt.Errorf("cos get bucket website error: %s, bucket: %s", err.Error(), bucket)
+		if ok && awsError.Code() == "NoSuchWebsiteConfiguration" {
 			return
 		}
+		log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+			logId, "get bucket website", request.String(), err.Error())
+		errRet = fmt.Errorf("cos get bucket website error: %s, bucket: %s", err.Error(), bucket)
 		return
 	}
 
@@ -380,6 +380,65 @@ func (me *CosService) GetBucketWebsite(ctx context.Context, bucket string) (webs
 	}
 	if len(website) > 0 {
 		websites = append(websites, website)
+	}
+
+	return
+}
+
+func (me *CosService) GetBucketEncryption(ctx context.Context, bucket string) (encryption string, errRet error) {
+	logId := getLogId(ctx)
+
+	request := s3.GetBucketEncryptionInput{
+		Bucket: aws.String(bucket),
+	}
+	ratelimit.Check("GetBucketEncryption")
+	response, err := me.client.UseCosClient().GetBucketEncryption(&request)
+	if err != nil {
+		awsError, ok := err.(awserr.Error)
+		if ok && awsError.Code() == "NoSuchEncryptionConfiguration" {
+			return
+		}
+		log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+			logId, "get bucket encryption", request.String(), err.Error())
+		errRet = fmt.Errorf("cos get bucket encryption error: %s, bucket: %s", err.Error(), bucket)
+		return
+	}
+
+	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+		logId, "get bucket encryption", request.String(), response.String())
+
+	if len(response.ServerSideEncryptionConfiguration.Rules) > 0 {
+		encryption = *response.ServerSideEncryptionConfiguration.Rules[0].ApplyServerSideEncryptionByDefault.SSEAlgorithm
+	}
+	return
+}
+
+func (me *CosService) GetBucketVersioning(ctx context.Context, bucket string) (versioningEnable bool, errRet error) {
+	logId := getLogId(ctx)
+
+	request := s3.GetBucketVersioningInput{
+		Bucket: aws.String(bucket),
+	}
+	ratelimit.Check("GetBucketVersioning")
+	response, err := me.client.UseCosClient().GetBucketVersioning(&request)
+	if err != nil {
+		awsError, ok := err.(awserr.Error)
+		if ok && awsError.Code() == "NoSuchVersioningConfiguration" {
+			return
+		}
+		log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+			logId, "get bucket versioning", request.String(), err.Error())
+		errRet = fmt.Errorf("cos get bucket versioning error: %s, bucket: %s", err.Error(), bucket)
+		return
+	}
+
+	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+		logId, "get bucket versioning", request.String(), response.String())
+
+	if response.Status == nil || *response.Status == "Suspended" {
+		versioningEnable = false
+	} else if *response.Status == "Enabled" {
+		versioningEnable = true
 	}
 
 	return

--- a/website/docs/r/cos_bucket.html.markdown
+++ b/website/docs/r/cos_bucket.html.markdown
@@ -80,8 +80,10 @@ The following arguments are supported:
 * `bucket` - (Required, ForceNew) The name of a bucket to be created. Bucket format should be [custom name]-[appid], for example `mycos-1258798060`.
 * `acl` - (Optional) The canned ACL to apply. Available values include private, public-read, and public-read-write. Defaults to private.
 * `cors_rules` - (Optional) A rule of Cross-Origin Resource Sharing (documented below).
+* `encryption_algorithm` - (Optional) The server-side encryption algorithm to use. Valid value is `AES256`.
 * `lifecycle_rules` - (Optional) A configuration of object lifecycle management (documented below).
 * `tags` - (Optional) The tags of a bucket.
+* `versioning_enable` - (Optional) Enable bucket versioning.
 * `website` - (Optional) A website object(documented below).
 
 The `cors_rules` object supports the following:

--- a/website/docs/r/scf_function.html.markdown
+++ b/website/docs/r/scf_function.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 * `role` - (Optional) Role of the SCF function.
 * `subnet_id` - (Optional) Subnet id of the SCF function.
 * `tags` - (Optional) Tags of the SCF function.
-* `timeout` - (Optional) Timeout of the SCF function, unit is second. Default `3`. Available value is 1-300.
+* `timeout` - (Optional) Timeout of the SCF function, unit is second. Default `3`. Available value is 1-900.
 * `triggers` - (Optional) Trigger list of the SCF function, note that if you modify the trigger list, all existing triggers will be deleted, and then create triggers in the new list. Each element contains the following attributes:
 * `vpc_id` - (Optional) VPC id of the SCF function.
 * `zip_file` - (Optional) Zip file of the SCF function, conflict with `cos_bucket_name`, `cos_object_name`, `cos_bucket_region`.


### PR DESCRIPTION
make testacc TESTARGS=" -run=TestAccTencentCloudCos"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudCos -timeout 120m
?       github.com/terraform-providers/terraform-provider-tencentcloud  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/gendoc   0.016s [no tests to run]
=== RUN   TestAccTencentCloudCosBucketObjectDataSource
=== PAUSE TestAccTencentCloudCosBucketObjectDataSource
=== RUN   TestAccTencentCloudCosBucketDataSource_basic
=== PAUSE TestAccTencentCloudCosBucketDataSource_basic
=== RUN   TestAccTencentCloudCosBucketDataSource_tags
--- PASS: TestAccTencentCloudCosBucketDataSource_tags (24.94s)
=== RUN   TestAccTencentCloudCosBucketDataSource_full
=== PAUSE TestAccTencentCloudCosBucketDataSource_full
=== RUN   TestAccTencentCloudCosBucketObject_source
=== PAUSE TestAccTencentCloudCosBucketObject_source
=== RUN   TestAccTencentCloudCosBucketObject_content
=== PAUSE TestAccTencentCloudCosBucketObject_content
=== RUN   TestAccTencentCloudCosBucketObject_storageClass
=== PAUSE TestAccTencentCloudCosBucketObject_storageClass
=== RUN   TestAccTencentCloudCosBucketObject_acl
=== PAUSE TestAccTencentCloudCosBucketObject_acl
=== RUN   TestAccTencentCloudCosBucket_basic
=== PAUSE TestAccTencentCloudCosBucket_basic
=== RUN   TestAccTencentCloudCosBucket_tags
=== PAUSE TestAccTencentCloudCosBucket_tags
=== RUN   TestAccTencentCloudCosBucket_cors
=== PAUSE TestAccTencentCloudCosBucket_cors
=== RUN   TestAccTencentCloudCosBucket_lifecycle
=== PAUSE TestAccTencentCloudCosBucket_lifecycle
=== RUN   TestAccTencentCloudCosBucket_website
=== PAUSE TestAccTencentCloudCosBucket_website
=== CONT  TestAccTencentCloudCosBucketObjectDataSource
=== CONT  TestAccTencentCloudCosBucket_basic
=== CONT  TestAccTencentCloudCosBucket_website
=== CONT  TestAccTencentCloudCosBucketObject_content
=== CONT  TestAccTencentCloudCosBucketObject_source
=== CONT  TestAccTencentCloudCosBucketObject_acl
=== CONT  TestAccTencentCloudCosBucket_lifecycle
=== CONT  TestAccTencentCloudCosBucketDataSource_full
--- PASS: TestAccTencentCloudCosBucketObject_source (10.27s)
=== CONT  TestAccTencentCloudCosBucketDataSource_basic
--- PASS: TestAccTencentCloudCosBucketObject_content (10.28s)
=== CONT  TestAccTencentCloudCosBucketObject_storageClass
--- PASS: TestAccTencentCloudCosBucketObjectDataSource (10.51s)
=== CONT  TestAccTencentCloudCosBucket_cors
--- PASS: TestAccTencentCloudCosBucketDataSource_full (10.93s)
=== CONT  TestAccTencentCloudCosBucket_tags
--- PASS: TestAccTencentCloudCosBucketObject_acl (11.18s)
--- PASS: TestAccTencentCloudCosBucket_website (14.45s)
--- PASS: TestAccTencentCloudCosBucket_lifecycle (14.96s)
--- PASS: TestAccTencentCloudCosBucket_basic (15.45s)
--- PASS: TestAccTencentCloudCosBucketObject_storageClass (10.15s)
--- PASS: TestAccTencentCloudCosBucketDataSource_basic (10.82s)
--- PASS: TestAccTencentCloudCosBucket_cors (14.63s)
--- PASS: TestAccTencentCloudCosBucket_tags (19.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud     55.180s