### PR TITLE
fix a condition for setting client certificate ids

### DIFF
--- a/tencentcloud/resource_tc_gaap_http_domain.go
+++ b/tencentcloud/resource_tc_gaap_http_domain.go
@@ -339,7 +339,7 @@ func resourceTencentCloudGaapHttpDomainRead(d *schema.ResourceData, m interface{
 	_ = d.Set("certificate_id", httpDomain.CertificateId)
 
 	var clientCertificateIds []*string
-	if httpDomain.PolyClientCertificateAliasInfo != nil && len(httpDomain.PolyClientCertificateAliasInfo) > 0 {
+	if len(httpDomain.PolyClientCertificateAliasInfo) > 0 {
 		clientCertificateIds = make([]*string, 0, len(httpDomain.PolyClientCertificateAliasInfo))
 		for _, info := range httpDomain.PolyClientCertificateAliasInfo {
 			clientCertificateIds = append(clientCertificateIds, info.CertificateId)

--- a/tencentcloud/resource_tc_gaap_http_domain.go
+++ b/tencentcloud/resource_tc_gaap_http_domain.go
@@ -339,7 +339,7 @@ func resourceTencentCloudGaapHttpDomainRead(d *schema.ResourceData, m interface{
 	_ = d.Set("certificate_id", httpDomain.CertificateId)
 
 	var clientCertificateIds []*string
-	if httpDomain.PolyClientCertificateAliasInfo != nil {
+	if httpDomain.PolyClientCertificateAliasInfo != nil && len(httpDomain.PolyClientCertificateAliasInfo) > 0 {
 		clientCertificateIds = make([]*string, 0, len(httpDomain.PolyClientCertificateAliasInfo))
 		for _, info := range httpDomain.PolyClientCertificateAliasInfo {
 			clientCertificateIds = append(clientCertificateIds, info.CertificateId)


### PR DESCRIPTION
In some cases, `httpDomain.PolyClientCertificateAliasInfo` was not nil but empty list and `terraform plan` failed.
fixed this bug.