### PR TITLE
fix cvm creation while its tags not sync issue

### DIFF
--- a/tencentcloud/common.go
+++ b/tencentcloud/common.go
@@ -191,6 +191,9 @@ func CheckNil(object interface{}, fields map[string]string) (nilFields []string)
 	return
 }
 
+// BuildTagResourceName builds the Tencent Clould specific name of a resource description.
+// The format is `qcs:project_id:service_type:region:account:resource`.
+// For more information, go to https://cloud.tencent.com/document/product/598/10606.
 func BuildTagResourceName(serviceType, resourceType, region, id string) string {
 	switch serviceType {
 	case "cos":

--- a/tencentcloud/resource_tc_instance.go
+++ b/tencentcloud/resource_tc_instance.go
@@ -542,12 +542,12 @@ func resourceTencentCloudInstanceCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	// tags
-	if v, ok := d.GetOk("tags"); ok {
+	if tmpTags := helper.GetTags(d, "tags"); len(tmpTags) > 0 {
 		tags := make([]*cvm.Tag, 0)
-		for key, value := range v.(map[string]interface{}) {
+		for k, v := range tmpTags {
 			tag := &cvm.Tag{
-				Key:   helper.String(key),
-				Value: helper.String(value.(string)),
+				Key:   helper.String(k),
+				Value: helper.String(v),
 			}
 			tags = append(tags, tag)
 		}
@@ -974,7 +974,7 @@ func resourceTencentCloudInstanceUpdate(d *schema.ResourceData, meta interface{}
 			client: meta.(*TencentCloudClient).apiV3Conn,
 		}
 		region := meta.(*TencentCloudClient).apiV3Conn.Region
-		resourceName := fmt.Sprintf("qcs::cvm:%s:uin/:instance/%s", region, instanceId)
+		resourceName := BuildTagResourceName("cvm", "instance", region, instanceId)
 		err := tagService.ModifyTags(ctx, resourceName, replaceTags, deleteTags)
 		if err != nil {
 			return err


### PR DESCRIPTION
When cvm created success, its tags may not attached at once, since it's async.
We use a dedicated [tag](https://cloud.tencent.com/document/api/651/35326) api to attach and makes its behavior like a sync one.