### PR TITLE
Add worker_config with resource `tencentcloud_kubernetes_cluster_attachment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.39.0 (Unreleased)
+
+ENHANCEMENTS:
+* Resource: `tencentcloud_kubernetes_cluster_attachment` add new argument `worker_config` to support config with existing instances.
+
 ## 1.38.2 (July 03, 2020)
 
 BUG FIXES:

--- a/tencentcloud/internal/helper/transform.go
+++ b/tencentcloud/internal/helper/transform.go
@@ -101,7 +101,7 @@ func BoolToInt64Pointer(s bool) (i *uint64) {
 	return
 }
 
-func BoolToInt64(s bool) (i *int64) {
+func BoolToInt64Ptr(s bool) (i *int64) {
 	result := int64(0)
 	if s {
 		result = int64(1)

--- a/tencentcloud/internal/helper/transform.go
+++ b/tencentcloud/internal/helper/transform.go
@@ -100,3 +100,12 @@ func BoolToInt64Pointer(s bool) (i *uint64) {
 	i = &result
 	return
 }
+
+func BoolToInt64(s bool) (i *int64) {
+	result := int64(0)
+	if s {
+		result = int64(1)
+	}
+	i = &result
+	return
+}

--- a/tencentcloud/resource_tc_cam_role.go
+++ b/tencentcloud/resource_tc_cam_role.go
@@ -16,7 +16,7 @@ resource "tencentcloud_cam_role" "foo" {
       "action": ["name/sts:AssumeRole"],
       "effect": "allow",
       "principal": {
-        "qcs": ["qcs::cam::uin/3374997817:uin/3374997817"]
+        "qcs": ["qcs::cam::uin/<your-account-id>:uin/<your-account-id>"]
       }
     }
   ]
@@ -40,7 +40,7 @@ resource "tencentcloud_cam_role" "boo" {
       "action": ["name/sts:AssumeRole", "name/sts:AssumeRoleWithWebIdentity"],
       "effect": "allow",
       "principal": {
-        "federated": ["qcs::cam::uin/3374997817:saml-provider/XXXX-oooo"]
+        "federated": ["qcs::cam::uin/<your-account-id>:saml-provider/<your-name>"]
       }
     }
   ]

--- a/tencentcloud/resource_tc_cam_role.go
+++ b/tencentcloud/resource_tc_cam_role.go
@@ -3,6 +3,8 @@ Provides a resource to create a CAM role.
 
 Example Usage
 
+Create normally
+
 ```hcl
 resource "tencentcloud_cam_role" "foo" {
   name          = "cam-role-test"
@@ -25,7 +27,7 @@ EOF
 }
 ```
 
-Created with SAML provider
+Create with SAML provider
 
 ```hcl
 resource "tencentcloud_cam_role" "boo" {
@@ -35,7 +37,7 @@ resource "tencentcloud_cam_role" "boo" {
   "version": "2.0",
   "statement": [
     {
-      "action": ["name/sts:AssumeRole"],
+      "action": ["name/sts:AssumeRole", "name/sts:AssumeRoleWithWebIdentity"],
       "effect": "allow",
       "principal": {
         "federated": ["qcs::cam::uin/3374997817:saml-provider/XXXX-oooo"]

--- a/tencentcloud/resource_tc_cam_role.go
+++ b/tencentcloud/resource_tc_cam_role.go
@@ -25,6 +25,30 @@ EOF
 }
 ```
 
+Created with SAML provider
+
+```hcl
+resource "tencentcloud_cam_role" "boo" {
+  name          = "cam-role-test"
+  document      = <<EOF
+{
+  "version": "2.0",
+  "statement": [
+    {
+      "action": ["name/sts:AssumeRole"],
+      "effect": "allow",
+      "principal": {
+        "federated": ["qcs::cam::uin/3374997817:saml-provider/XXXX-oooo"]
+      }
+    }
+  ]
+}
+EOF
+  description   = "test"
+  console_login = true
+}
+```
+
 Import
 
 CAM role can be imported using the id, e.g.

--- a/tencentcloud/resource_tc_kubernetes_cluster_attachment.go
+++ b/tencentcloud/resource_tc_kubernetes_cluster_attachment.go
@@ -153,7 +153,7 @@ func TkeInstanceAdvancedSetting() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			ForceNew:    true,
 			Optional:    true,
-			Description: "Ase64-encoded User Data text, the length limit is 16KB.",
+			Description: "Base64-encoded User Data text, the length limit is 16KB.",
 		},
 		"is_schedule": {
 			Type:        schema.TypeBool,
@@ -253,7 +253,7 @@ func tkeGetInstanceAdvancedPara(dMap map[string]interface{}, meta interface{}) (
 		}
 	}
 
-	setting.Unschedulable = helper.BoolToInt64(!dMap["is_schedule"].(bool))
+	setting.Unschedulable = helper.BoolToInt64Ptr(!dMap["is_schedule"].(bool))
 
 	if v, ok := dMap["user_data"]; ok {
 		setting.UserScript = helper.String(v.(string))

--- a/tencentcloud/resource_tc_kubernetes_cluster_attachment.go
+++ b/tencentcloud/resource_tc_kubernetes_cluster_attachment.go
@@ -149,7 +149,7 @@ func TkeInstanceAdvancedSetting() map[string]*schema.Schema {
 				},
 			},
 		},
-		"user_script": {
+		"user_data": {
 			Type:        schema.TypeString,
 			ForceNew:    true,
 			Optional:    true,
@@ -255,7 +255,7 @@ func tkeGetInstanceAdvancedPara(dMap map[string]interface{}, meta interface{}) (
 
 	setting.Unschedulable = helper.BoolToInt64(!dMap["is_schedule"].(bool))
 
-	if v, ok := dMap["user_script"]; ok {
+	if v, ok := dMap["user_data"]; ok {
 		setting.UserScript = helper.String(v.(string))
 	}
 

--- a/tencentcloud/resource_tc_kubernetes_cluster_attachment.go
+++ b/tencentcloud/resource_tc_kubernetes_cluster_attachment.go
@@ -108,6 +108,63 @@ import (
 	"github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/ratelimit"
 )
 
+func TkeInstanceAdvancedSetting() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"mount_target": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+			Description: "Mount target. Default is not mounting.",
+		},
+		"docker_graph_path": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+			Default:     "/var/lib/docker",
+			Description: "Docker graph path. Default is `/var/lib/docker`.",
+		},
+		"data_disk": {
+			Type:        schema.TypeList,
+			ForceNew:    true,
+			Optional:    true,
+			MaxItems:    11,
+			Description: "Configurations of data disk.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"disk_type": {
+						Type:         schema.TypeString,
+						ForceNew:     true,
+						Optional:     true,
+						Default:      SYSTEM_DISK_TYPE_CLOUD_PREMIUM,
+						ValidateFunc: validateAllowedStringValue(SYSTEM_DISK_ALLOW_TYPE),
+						Description:  "Types of disk, available values: CLOUD_PREMIUM and CLOUD_SSD.",
+					},
+					"disk_size": {
+						Type:        schema.TypeInt,
+						ForceNew:    true,
+						Optional:    true,
+						Default:     0,
+						Description: "Volume of disk in GB. Default is 0.",
+					},
+				},
+			},
+		},
+		"user_script": {
+			Type:        schema.TypeString,
+			ForceNew:    true,
+			Optional:    true,
+			Description: "Ase64-encoded User Data text, the length limit is 16KB.",
+		},
+		"is_schedule": {
+			Type:        schema.TypeBool,
+			ForceNew:    true,
+			Optional:    true,
+			Default:     true,
+			Description: "Indicate to schedule the adding node or not. Default is true.",
+		},
+	}
+}
+
 func resourceTencentCloudTkeClusterAttachment() *schema.Resource {
 	schemaBody := map[string]*schema.Schema{
 		"cluster_id": {
@@ -138,7 +195,16 @@ func resourceTencentCloudTkeClusterAttachment() *schema.Resource {
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			Description: "The key pair to use for the instance, it looks like skey-16jig7tx, it should be set if `password` not set.",
 		},
-
+		"worker_config": {
+			Type:     schema.TypeList,
+			ForceNew: true,
+			MaxItems: 1,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: TkeInstanceAdvancedSetting(),
+			},
+			Description: "Deploy the machine configuration information of the 'WORKER', commonly used to attach existing instances.",
+		},
 		//compute
 		"security_groups": {
 			Type:        schema.TypeSet,
@@ -162,6 +228,43 @@ func resourceTencentCloudTkeClusterAttachment() *schema.Resource {
 	}
 }
 
+func tkeGetInstanceAdvancedPara(dMap map[string]interface{}, meta interface{}) (setting tke.InstanceAdvancedSettings) {
+	setting = tke.InstanceAdvancedSettings{}
+	if v, ok := dMap["mount_target"]; ok {
+		setting.MountTarget = helper.String(v.(string))
+	}
+
+	if v, ok := dMap["data_disk"]; ok {
+
+		dataDisks := v.([]interface{})
+		setting.DataDisks = make([]*tke.DataDisk, 0, len(dataDisks))
+
+		for _, d := range dataDisks {
+			var (
+				value    = d.(map[string]interface{})
+				diskType = value["disk_type"].(string)
+				diskSize = int64(value["disk_size"].(int))
+				dataDisk = tke.DataDisk{
+					DiskType: &diskType,
+					DiskSize: &diskSize,
+				}
+			)
+			setting.DataDisks = append(setting.DataDisks, &dataDisk)
+		}
+	}
+
+	setting.Unschedulable = helper.BoolToInt64(!dMap["is_schedule"].(bool))
+
+	if v, ok := dMap["user_script"]; ok {
+		setting.UserScript = helper.String(v.(string))
+	}
+
+	if v, ok := dMap["docker_graph_path"]; ok {
+		setting.DockerGraphPath = helper.String(v.(string))
+	}
+
+	return setting
+}
 func resourceTencentCloudTkeClusterAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 	defer logElapsed("resource.tencentcloud_kubernetes_cluster_attachment.read")()
 	defer inconsistentCheck(d, meta)()
@@ -282,6 +385,14 @@ func resourceTencentCloudTkeClusterAttachmentCreate(d *schema.ResourceData, meta
 	}
 
 	request.InstanceAdvancedSettings = &tke.InstanceAdvancedSettings{}
+	if workConfig, ok := d.GetOk("worker_config"); ok {
+		workConfigList := workConfig.([]interface{})
+		if len(workConfigList) == 1 {
+			workConfigPara := workConfigList[0].(map[string]interface{})
+			setting := tkeGetInstanceAdvancedPara(workConfigPara, meta)
+			request.InstanceAdvancedSettings = &setting
+		}
+	}
 
 	request.InstanceAdvancedSettings.Labels = GetTkeLabels(d, "labels")
 

--- a/website/docs/r/cam_role.html.markdown
+++ b/website/docs/r/cam_role.html.markdown
@@ -25,7 +25,7 @@ resource "tencentcloud_cam_role" "foo" {
       "action": ["name/sts:AssumeRole"],
       "effect": "allow",
       "principal": {
-        "qcs": ["qcs::cam::uin/3374997817:uin/3374997817"]
+        "qcs": ["qcs::cam::uin/<your-account-id>:uin/<your-account-id>"]
       }
     }
   ]
@@ -49,7 +49,7 @@ resource "tencentcloud_cam_role" "boo" {
       "action": ["name/sts:AssumeRole", "name/sts:AssumeRoleWithWebIdentity"],
       "effect": "allow",
       "principal": {
-        "federated": ["qcs::cam::uin/3374997817:saml-provider/XXXX-oooo"]
+        "federated": ["qcs::cam::uin/<your-account-id>:saml-provider/<your-name>"]
       }
     }
   ]

--- a/website/docs/r/cam_role.html.markdown
+++ b/website/docs/r/cam_role.html.markdown
@@ -34,6 +34,30 @@ EOF
 }
 ```
 
+Created with SAML provider
+
+```hcl
+resource "tencentcloud_cam_role" "boo" {
+  name          = "cam-role-test"
+  document      = <<EOF
+{
+  "version": "2.0",
+  "statement": [
+    {
+      "action": ["name/sts:AssumeRole"],
+      "effect": "allow",
+      "principal": {
+        "federated": ["qcs::cam::uin/3374997817:saml-provider/XXXX-oooo"]
+      }
+    }
+  ]
+}
+EOF
+  description   = "test"
+  console_login = true
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/cam_role.html.markdown
+++ b/website/docs/r/cam_role.html.markdown
@@ -12,6 +12,8 @@ Provides a resource to create a CAM role.
 
 ## Example Usage
 
+Create normally
+
 ```hcl
 resource "tencentcloud_cam_role" "foo" {
   name          = "cam-role-test"
@@ -34,7 +36,7 @@ EOF
 }
 ```
 
-Created with SAML provider
+Create with SAML provider
 
 ```hcl
 resource "tencentcloud_cam_role" "boo" {
@@ -44,7 +46,7 @@ resource "tencentcloud_cam_role" "boo" {
   "version": "2.0",
   "statement": [
     {
-      "action": ["name/sts:AssumeRole"],
+      "action": ["name/sts:AssumeRole", "name/sts:AssumeRoleWithWebIdentity"],
       "effect": "allow",
       "principal": {
         "federated": ["qcs::cam::uin/3374997817:saml-provider/XXXX-oooo"]

--- a/website/docs/r/kubernetes_cluster_attachment.html.markdown
+++ b/website/docs/r/kubernetes_cluster_attachment.html.markdown
@@ -108,6 +108,20 @@ The following arguments are supported:
 * `key_ids` - (Optional, ForceNew) The key pair to use for the instance, it looks like skey-16jig7tx, it should be set if `password` not set.
 * `labels` - (Optional, ForceNew) Labels of tke attachment exits cvm.
 * `password` - (Optional, ForceNew) Password to access, should be set if `key_ids` not set.
+* `worker_config` - (Optional, ForceNew) Deploy the machine configuration information of the 'WORKER', commonly used to attach existing instances.
+
+The `data_disk` object supports the following:
+
+* `disk_size` - (Optional, ForceNew) Volume of disk in GB. Default is 0.
+* `disk_type` - (Optional, ForceNew) Types of disk, available values: CLOUD_PREMIUM and CLOUD_SSD.
+
+The `worker_config` object supports the following:
+
+* `data_disk` - (Optional, ForceNew) Configurations of data disk.
+* `docker_graph_path` - (Optional, ForceNew) Docker graph path. Default is `/var/lib/docker`.
+* `is_schedule` - (Optional, ForceNew) Indicate to schedule the adding node or not. Default is true.
+* `mount_target` - (Optional, ForceNew) Mount target. Default is not mounting.
+* `user_script` - (Optional, ForceNew) Ase64-encoded User Data text, the length limit is 16KB.
 
 ## Attributes Reference
 

--- a/website/docs/r/kubernetes_cluster_attachment.html.markdown
+++ b/website/docs/r/kubernetes_cluster_attachment.html.markdown
@@ -121,7 +121,7 @@ The `worker_config` object supports the following:
 * `docker_graph_path` - (Optional, ForceNew) Docker graph path. Default is `/var/lib/docker`.
 * `is_schedule` - (Optional, ForceNew) Indicate to schedule the adding node or not. Default is true.
 * `mount_target` - (Optional, ForceNew) Mount target. Default is not mounting.
-* `user_script` - (Optional, ForceNew) Ase64-encoded User Data text, the length limit is 16KB.
+* `user_data` - (Optional, ForceNew) Ase64-encoded User Data text, the length limit is 16KB.
 
 ## Attributes Reference
 

--- a/website/docs/r/kubernetes_cluster_attachment.html.markdown
+++ b/website/docs/r/kubernetes_cluster_attachment.html.markdown
@@ -121,7 +121,7 @@ The `worker_config` object supports the following:
 * `docker_graph_path` - (Optional, ForceNew) Docker graph path. Default is `/var/lib/docker`.
 * `is_schedule` - (Optional, ForceNew) Indicate to schedule the adding node or not. Default is true.
 * `mount_target` - (Optional, ForceNew) Mount target. Default is not mounting.
-* `user_data` - (Optional, ForceNew) Ase64-encoded User Data text, the length limit is 16KB.
+* `user_data` - (Optional, ForceNew) Base64-encoded User Data text, the length limit is 16KB.
 
 ## Attributes Reference
 


### PR DESCRIPTION
With existing instances test case, the case need an exsting instance, therefor not put it into test file to make auto-tests.

```
 make testacc TESTARGS=" -run=TestAccTencentCloudTkeAttachExistResource"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudTkeAttachExistResource -timeout 120m
?       github.com/terraform-providers/terraform-provider-tencentcloud  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/gendoc  (cached) [no tests to run]
=== RUN   TestAccTencentCloudTkeAttachExistResource
--- PASS: TestAccTencentCloudTkeAttachExistResource (336.47s)
PASS
ok      github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud     337.703s
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/connectivity        [no test files]
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/internal/helper     [no test files]
?       github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/ratelimit   [no test files]

```