### PR TITLE
datasource images support snapshotSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.39.0 (Unreleased)
 
 ENHANCEMENTS:
+
+* Data Source: `tencentcloud_images` supports list of snapshots.
 * Resource: `tencentcloud_kubernetes_cluster_attachment` add new argument `worker_config` to support config with existing instances.
 
 ## 1.38.2 (July 03, 2020)

--- a/tencentcloud/data_source_tc_images.go
+++ b/tencentcloud/data_source_tc_images.go
@@ -268,7 +268,7 @@ func dataSourceTencentCloudImagesRead(d *schema.ResourceData, meta interface{}) 
 	imageList := make([]map[string]interface{}, 0, len(results))
 	ids := make([]string, 0, len(results))
 	for _, image := range results {
-		snapshots, err := imagesReadSnapshotByIds(image, cbsService, ctx)
+		snapshots, err := imagesReadSnapshotByIds(ctx, cbsService, image)
 		if err != nil {
 			return err
 		}
@@ -311,7 +311,7 @@ func dataSourceTencentCloudImagesRead(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func imagesReadSnapshotByIds(image *cvm.Image, cbsService CbsService, ctx context.Context) (snapshotResults []map[string]interface{}, errSnap error) {
+func imagesReadSnapshotByIds(ctx context.Context, cbsService CbsService, image *cvm.Image) (snapshotResults []map[string]interface{}, errSnap error) {
 	if len(image.SnapshotSet) == 0 {
 		return
 	}

--- a/tencentcloud/data_source_tc_images.go
+++ b/tencentcloud/data_source_tc_images.go
@@ -322,14 +322,7 @@ func imagesReadSnapshotByIds(ctx context.Context, cbsService CbsService, image *
 		snapshotByIds = append(snapshotByIds, snapshot.SnapshotId)
 	}
 
-	var snapshots []*cbs.Snapshot
-	errSnap = resource.Retry(readRetryTimeout, func() *resource.RetryError {
-		snapshots, errSnap = cbsService.DescribeSnapshotByIds(ctx, snapshotByIds)
-		if errSnap != nil {
-			return retryError(errSnap, InternalError)
-		}
-		return nil
-	})
+	snapshots, errSnap := cbsService.DescribeSnapshotByIds(ctx, snapshotByIds)
 	if errSnap != nil {
 		return
 	}

--- a/tencentcloud/data_source_tc_images_test.go
+++ b/tencentcloud/data_source_tc_images_test.go
@@ -45,12 +45,13 @@ func TestAccTencentCloudDataSourceImagesBase(t *testing.T) {
 
 const testAccTencentCloudDataSourceImagesBase = `
 data "tencentcloud_images" "foo" {
+	result_output_file = "data_source_tc_images_test.txt"
 }
 `
 
 const testAccTencentCloudDataSourceImagesBaseWithFilter = `
 data "tencentcloud_images" "foo" {
-	image_type = ["PUBLIC_IMAGE"]
+	image_type = ["PRIVATE_IMAGE"]
 }
 `
 

--- a/tencentcloud/service_tencentcloud_cbs.go
+++ b/tencentcloud/service_tencentcloud_cbs.go
@@ -260,9 +260,6 @@ func (me *CbsService) DescribeSnapshotByIds(ctx context.Context, snapshotIdsPara
 			errRet = err
 			return
 		}
-		if len(response.Response.SnapshotSet) < 1 {
-			break
-		}
 
 		snapshots = append(snapshots, response.Response.SnapshotSet...)
 		if len(response.Response.SnapshotSet) < int(pageSize) {

--- a/tencentcloud/service_tencentcloud_cbs.go
+++ b/tencentcloud/service_tencentcloud_cbs.go
@@ -250,7 +250,7 @@ func (me *CbsService) DescribeSnapshotByIds(ctx context.Context, snapshotIdsPara
 		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
 			logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
 
-		if response == nil || len(response.Response.SnapshotSet) < 1 {
+		if len(response.Response.SnapshotSet) < 1 {
 			break
 		}
 

--- a/tencentcloud/service_tencentcloud_cbs.go
+++ b/tencentcloud/service_tencentcloud_cbs.go
@@ -258,9 +258,6 @@ func (me *CbsService) DescribeSnapshotByIds(ctx context.Context, snapshotIdsPara
 			errRet = err
 			return
 		}
-		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
-			logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
-
 		if len(response.Response.SnapshotSet) < 1 {
 			break
 		}

--- a/website/docs/d/images.html.markdown
+++ b/website/docs/d/images.html.markdown
@@ -46,6 +46,11 @@ In addition to all arguments above, the following attributes are exported:
   * `image_type` - Type of the image.
   * `os_name` - OS name of the image.
   * `platform` - Platform of the image.
+  * `snapshots` - List of snapshot details.
+    * `disk_size` - Size of the cloud disk used to create the snapshot; unit: GB.
+    * `disk_usage` - Type of the cloud disk used to create the snapshot.
+    * `snapshot_id` - Snapshot ID.
+    * `snapshot_name` - Snapshot name, the user-defined snapshot alias.
   * `support_cloud_init` - Whether support cloud-init.
   * `sync_percent` - Sync percent of the image.
 


### PR DESCRIPTION
 $ make testacc TESTARGS=" -run=TestAccTencentCloudDataSourceImagesBase"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccTencentCloudDataSourceImagesBase -timeout 120m
?   	github.com/terraform-providers/terraform-provider-tencentcloud	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-tencentcloud/gendoc	(cached) [no tests to run]

=== RUN   TestAccTencentCloudDataSourceImagesBase
--- PASS: TestAccTencentCloudDataSourceImagesBase (13.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud	13.912s
?   	github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/connectivity	[no test files]
?   	github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/internal/helper	[no test files]
?   	github.com/terraform-providers/terraform-provider-tencentcloud/tencentcloud/ratelimit	[no test files]